### PR TITLE
[feature] : 게시판 세부 수정, 게시판 삭제와 동시에 관련된 댓글 삭제

### DIFF
--- a/src/main/java/HomePage/config/SpringConfig.java
+++ b/src/main/java/HomePage/config/SpringConfig.java
@@ -34,7 +34,7 @@ public class SpringConfig {
 
     @Bean
     public CommunityBoardService communityBoardService(){
-        return new CommunityBoardService(communityBoardRepository());
+        return new CommunityBoardService(communityBoardRepository(), communityCommentRepository());
     }
 
     @Bean

--- a/src/main/java/HomePage/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/HomePage/config/jwt/JwtAuthenticationFilter.java
@@ -17,7 +17,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 
 
@@ -42,28 +41,32 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException{
         System.out.println("JwtAuthentication : 로그인 시도중");
         try {
-            BufferedReader br = request.getReader();
-            String input = null;
-            String data = "";
-            while ((input = br.readLine()) != null) {
-                data += input;
-            }
-            System.out.println(data);
-            String parsedUsername = null;
-            String parsedPassword = null;
-            // parse
-            String[] pairs = data.split("&");
-            for (String pair : pairs) {
-                String[] keyValue = pair.split("=");
-                if (keyValue[0].equals("username")) {
-                    parsedUsername = keyValue[1];
-                } else if (keyValue[0].equals("password")) {
-                    parsedPassword = keyValue[1];
-                }
-            }
-            System.out.println("Username: " + parsedUsername);
-            System.out.println("Password: " + parsedPassword);
-          
+//            BufferedReader br = request.getReader();
+//            String input = null;
+//            String data = "";
+//            while ((input = br.readLine()) != null) {
+//                data += input;
+//            }
+//            System.out.println(data);
+//            String parsedUsername = null;
+//            String parsedPassword = null;
+//            // parse
+//            String[] pairs = data.split("&");
+//            for (String pair : pairs) {
+//                String[] keyValue = pair.split("=");
+//                if (keyValue[0].equals("username")) {
+//                    parsedUsername = keyValue[1];
+//                } else if (keyValue[0].equals("password")) {
+//                    parsedPassword = keyValue[1];
+//                }
+//            }
+//            System.out.println("Username: " + parsedUsername);
+//            System.out.println("Password: " + parsedPassword);
+            String parsedUsername = request.getParameter("username");
+            String parsedPassword = request.getParameter("password");
+            System.out.println(parsedUsername);
+            System.out.println(parsedPassword);
+
             UsernamePasswordAuthenticationToken authenticationToken =
                     new UsernamePasswordAuthenticationToken(parsedUsername, parsedPassword);
             Authentication authentication = authenticationManager.authenticate(authenticationToken);
@@ -82,8 +85,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             }catch (ServletException e3){
                 System.out.println("next2");
             }
-        }catch (IOException e1){
-            System.out.println("next3");
         }
         return null;
     }

--- a/src/main/java/HomePage/controller/board/CommunityBoardController.java
+++ b/src/main/java/HomePage/controller/board/CommunityBoardController.java
@@ -1,12 +1,10 @@
 package HomePage.controller.board;
 
-import HomePage.config.auth.PrincipalDetails;
 import HomePage.domain.model.CommunityBoard;
 import HomePage.domain.model.CommunityComment;
 import HomePage.domain.model.Page;
 import HomePage.service.CommunityBoardService;
 import HomePage.service.CommunityCommentService;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -97,34 +95,5 @@ public class CommunityBoardController {
         return "/board/boardViewDetail";
     }
 
-    @GetMapping("/{id}/edit")
-    public String showEditForm(@PathVariable Long id, Model model, Authentication authentication){
-        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-        String currentUsername = principalDetails.getUsername();
 
-        CommunityBoard board = boardService.getBoardById(id); // 게시판 정보 불러오기
-
-        // 게시판이 없는 경우 리턴
-        if (board == null){
-            return "error/404";
-        }
-
-        // 해당 유저의 게시글이 맞는지 권한 체크
-        if (!hasEditPermission(board, principalDetails)){
-            return "error/403";
-        }
-
-        model.addAttribute("board", board);
-
-        return "/board/boardEditView";
-    }
-
-    private boolean hasEditPermission(CommunityBoard board, PrincipalDetails principalDetails) {
-          String currentUsername = principalDetails.getUsername();
-          return board.getWriter().equals(currentUsername) || isAdmin(principalDetails);
-    }
-
-    private boolean isAdmin(PrincipalDetails principalDetails){
-        return principalDetails.getUser().getRoles().contains("ADMIN");
-    }
 }

--- a/src/main/java/HomePage/controller/board/api/CommunityBoardApiController.java
+++ b/src/main/java/HomePage/controller/board/api/CommunityBoardApiController.java
@@ -4,15 +4,14 @@ import HomePage.config.auth.PrincipalDetails;
 import HomePage.controller.board.form.CommunityBoardWriteForm;
 import HomePage.domain.model.CommunityBoard;
 import HomePage.service.CommunityBoardService;
+import HomePage.service.CommunityCommentService;
 import jakarta.validation.Valid;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.Map;
@@ -21,9 +20,11 @@ import java.util.Map;
 @RequestMapping("/api/v1/community")
 public class CommunityBoardApiController {
     private final CommunityBoardService boardService;
+    private final CommunityCommentService commentService;
 
-    public CommunityBoardApiController(CommunityBoardService boardService) {
+    public CommunityBoardApiController(CommunityBoardService boardService, CommunityCommentService commentService) {
         this.boardService = boardService;
+        this.commentService = commentService;
     }
 
     @GetMapping("/write")
@@ -56,6 +57,92 @@ public class CommunityBoardApiController {
         boardService.saveBoard(board);
         return "redirect:/community/list";
     }
+    @DeleteMapping("/{id}/delete")
+    public String deleteBoard(@PathVariable Long id, Authentication authentication){
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        String currentUsername = principalDetails.getUsername();
 
+        CommunityBoard board = boardService.getBoardById(id);
+
+        if (board == null){
+            return "error/404";
+        }
+
+        if (!hasEditPermission(board, principalDetails)){
+            return "error/403";
+        }
+
+        boardService.deleteBoard(id); // 게시글 삭제, 게시글 관련된 댓글들도 삭제
+
+        return "redirect:/community/list";
+    }
+
+
+    @GetMapping("/{id}/editForm")
+    public String showBoardEditForm(@PathVariable Long id, Model model, Authentication authentication){
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        String currentUsername = principalDetails.getUsername();
+
+        CommunityBoard board = boardService.getBoardById(id); // 게시판 정보 불러오기
+
+        // 게시판이 없는 경우 리턴
+        if (board == null){
+            return "error/404";
+        }
+
+        // 해당 유저의 게시글이 맞는지 권한 체크
+        if (!hasEditPermission(board, principalDetails)){
+            return "error/403";
+        }
+
+        model.addAttribute("article", board);
+
+        return "/board/boardEditView";
+    }
+    @PutMapping("/{id}/edit")
+    public String editBoard(@Valid CommunityBoardWriteForm boardWriteForm,
+                            Errors errors, @PathVariable Long id, Model model){
+        // Error errors는 @Valid 매개변수 다음으로 와야합니다. 그렇지 않으면 정상적으로 동작하지 않습니다.
+        CommunityBoard board = boardService.getBoardById(id);
+
+        if (errors.hasErrors()){
+           model.addAttribute("communityBoardWriteForm", boardWriteForm);
+           model.addAttribute("article", board);
+
+           Map<String, String> validatorResult = boardService.validateCommunityForm(errors);
+           for (String key : validatorResult.keySet()){
+               model.addAttribute(key, validatorResult.get(key));
+           }
+           // 유효성 검사에 실패하여 페이지 폼으로 리턴
+           return "board/boardEditView";
+        }
+
+        board.setTitle(boardWriteForm.getTitle());
+        board.setContent(boardWriteForm.getContent());
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        String currentUsername = principalDetails.getUsername();
+
+        if (board == null){
+            return "error/404";
+        }
+
+        // 해당 유저의 게시글이 맞는지 권한 체크
+        if (!hasEditPermission(board, principalDetails)){
+            return "error/403";
+        }
+        boardService.updateBoard(board);
+
+        return "redirect:/community/list";
+    }
+
+    private boolean hasEditPermission(CommunityBoard board, PrincipalDetails principalDetails) {
+          String currentUsername = principalDetails.getUsername();
+          return board.getWriter().equals(currentUsername) || isAdmin(principalDetails);
+    }
+
+    private boolean isAdmin(PrincipalDetails principalDetails){
+        return principalDetails.getUser().getRoles().contains("ADMIN");
+    }
 
 }

--- a/src/main/java/HomePage/controller/board/comment/api/CommunityCommentApiController.java
+++ b/src/main/java/HomePage/controller/board/comment/api/CommunityCommentApiController.java
@@ -25,9 +25,11 @@ public class CommunityCommentApiController {
         comment.setContent(content);
         comment.setWriter(principalDetails.getUsername());
         comment.setBoard_id(articleId);
-        System.out.println(principalDetails.getUsername());
+
         commentService.saveComment(comment);
 
         return "redirect:/articles/" + articleId;
     }
+
+
 }

--- a/src/main/java/HomePage/exception/GlobalExceptionHandler.java
+++ b/src/main/java/HomePage/exception/GlobalExceptionHandler.java
@@ -2,8 +2,13 @@ package HomePage.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -22,5 +27,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomBadCredentialsException.class)
     public ResponseEntity<String> handleCustomBadCredentialsException(CustomBadCredentialsException ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("자격 증명 실패");
+    }
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public String handleValidationExceptions(MethodArgumentNotValidException ex, Model model) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+            errors.put("valid_" + error.getField(), error.getDefaultMessage())
+        );
+        model.addAllAttributes(errors);
+        return "board/boardEditView";  // 에러가 있을 경우 폼 페이지로 다시 이동
     }
 }

--- a/src/main/java/HomePage/repository/BoardRepository.java
+++ b/src/main/java/HomePage/repository/BoardRepository.java
@@ -11,7 +11,7 @@ public interface BoardRepository<T extends Board>{
     T save(T board);
 
     boolean update(T board);
-    boolean deleteByWriter(String writer);
+    boolean deleteById(Long id);
 
     Optional<T> selectById(Long id);
     Optional<T> selectByTitle(String title);

--- a/src/main/java/HomePage/repository/CommentRepository.java
+++ b/src/main/java/HomePage/repository/CommentRepository.java
@@ -10,6 +10,8 @@ public interface CommentRepository <T extends Comment> {
     List<T> selectAll();
     boolean update(T comment);
     boolean deleteByWriter(String writer);
+    boolean deleteByCommentId(Long id);
+    boolean deleteByBoardId(Long id);
     List<T> selectById(Long id);
     Optional<T> findCommentById(Long commentId);
     int countByBoardId(Long boardId);

--- a/src/main/java/HomePage/repository/JdbcTemplateCommunityBoardRepository.java
+++ b/src/main/java/HomePage/repository/JdbcTemplateCommunityBoardRepository.java
@@ -62,12 +62,9 @@ public class JdbcTemplateCommunityBoardRepository implements BoardRepository<Com
     }
 
     @Override
-    public boolean deleteByWriter(String writer) {
-        int isDelete = jdbcTemplate.update("DELETE FROM security.communityboard WHERE writer = ?", writer);
-        if (isDelete == 0 || isDelete > 1){
-            return false;
-        }
-        return true;
+    public boolean deleteById(Long id) {
+        int isDelete = jdbcTemplate.update("DELETE FROM security.communityboard WHERE board_id = ?", id);
+        return isDelete == 1;
     }
 
     @Override

--- a/src/main/java/HomePage/repository/JdbcTemplateCommunityCommentRepository.java
+++ b/src/main/java/HomePage/repository/JdbcTemplateCommunityCommentRepository.java
@@ -76,11 +76,21 @@ public class JdbcTemplateCommunityCommentRepository implements CommentRepository
     @Override
     public boolean deleteByWriter(String writer) {
         int isDelete = jdbcTemplate.update("DELETE FROM security.communitycomment WHERE writer = ?", writer);
-        if (isDelete == 0 || isDelete > 1){
-            return false;
-        }
-        return true;
+        return isDelete == 1;
     }
+
+    @Override
+    public boolean deleteByCommentId(Long id) {
+        int isDelete = jdbcTemplate.update("DELETE FROM security.communitycomment WHERE id = ?", id);
+        return isDelete == 1;
+    }
+
+    @Override
+    public boolean deleteByBoardId(Long id) {
+        int isDelete = jdbcTemplate.update("DELETE FROM security.communitycomment WHERE board_id = ?", id);
+        return isDelete >= 1;
+    }
+
     private RowMapper<CommunityComment> communityCommentRowMapper(){
        return (rs, rowNum) -> {
            CommunityComment communityComment = new CommunityComment();

--- a/src/main/java/HomePage/repository/JdbcTemplateReviewBoardRepository.java
+++ b/src/main/java/HomePage/repository/JdbcTemplateReviewBoardRepository.java
@@ -62,13 +62,10 @@ public class JdbcTemplateReviewBoardRepository implements BoardRepository<Review
         return true;
     }
 
+
     @Override
-    public boolean deleteByWriter(String writer) {
-        int isDelete = jdbcTemplate.update("DELETE FROM security.reviewBoard WHERE writer = ?", writer);
-        if (isDelete == 0 || isDelete > 1){
-            return false;
-        }
-        return true;
+    public boolean deleteById(Long id) {
+        return false;
     }
 
     @Override

--- a/src/main/java/HomePage/service/CommentService.java
+++ b/src/main/java/HomePage/service/CommentService.java
@@ -7,7 +7,9 @@ import java.util.List;
 public interface CommentService <T extends Comment> {
     void saveComment(T Comment);
     void updateComment(T Comment);
-    void deleteComment(Long id);
+    void deleteCommentByCommentId(Long id);
+    void deleteCommentByWriter(String writer);
+    void deleteCommentsByBoardId(Long id);
     T getCommentByCommentId(Long CommentId);
     List<T> getCommentByBoardId(Long board_id);
     List<T> getAllComments();

--- a/src/main/java/HomePage/service/CommunityBoardService.java
+++ b/src/main/java/HomePage/service/CommunityBoardService.java
@@ -1,9 +1,10 @@
 package HomePage.service;
 
 import HomePage.domain.model.CommunityBoard;
+import HomePage.domain.model.CommunityComment;
 import HomePage.domain.model.Page;
 import HomePage.repository.BoardRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import HomePage.repository.CommentRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.Errors;
@@ -21,14 +22,13 @@ public class CommunityBoardService implements BoardService<CommunityBoard>{
     int pageSize;
 
     private final BoardRepository<CommunityBoard> communityBoardRepository;
+    private final CommentRepository<CommunityComment> communityCommentRepository;
 
 
-
-    @Autowired
-    public CommunityBoardService(BoardRepository<CommunityBoard> communityBoardRepository) {
+    public CommunityBoardService(BoardRepository<CommunityBoard> communityBoardRepository, CommentRepository<CommunityComment> communityCommentRepository) {
         this.communityBoardRepository = communityBoardRepository;
+        this.communityCommentRepository = communityCommentRepository;
     }
-
 
     @Transactional(readOnly = true)
     public Map<String, String> validateCommunityForm(Errors errors){
@@ -72,11 +72,15 @@ public class CommunityBoardService implements BoardService<CommunityBoard>{
         }
     }
 
+
     @Override
+    @Transactional
     public void deleteBoard(Long id) {
-        CommunityBoard board = getBoardById(id);
-        if (!communityBoardRepository.deleteByWriter(board.getWriter())) {
-            throw new RuntimeException("Failed to delete board with id: " + id);
+        if(!communityCommentRepository.deleteByBoardId(id)){
+            throw new RuntimeException("Failed to delete comment with board_id: " + id);
+        }
+        if (!communityBoardRepository.deleteById(id)) {
+            throw new RuntimeException("Failed to delete board with board_id: " + id);
         }
     }
 

--- a/src/main/java/HomePage/service/CommunityCommentService.java
+++ b/src/main/java/HomePage/service/CommunityCommentService.java
@@ -38,10 +38,24 @@ public class CommunityCommentService implements CommentService<CommunityComment>
     }
 
     @Override
-    public void deleteComment(Long id) {
+    public void deleteCommentByCommentId(Long id) {
         CommunityComment comment = getCommentByCommentId(id);
-        if (!commentRepository.deleteByWriter(comment.getWriter())) {
-            throw new RuntimeException("Failed to delete board with id: " + id);
+        if (!commentRepository.deleteByCommentId(comment.getId())) {
+            throw new RuntimeException("Failed to delete board with comment_id: " + id);
+        }
+    }
+
+    @Override
+    public void deleteCommentsByBoardId(Long id) {
+        if(!commentRepository.deleteByBoardId(id)){
+            throw new RuntimeException("Failed to delete board with board_id: " + id);
+        }
+    }
+
+    @Override
+    public void deleteCommentByWriter(String writer) {
+        if (!commentRepository.deleteByWriter(writer)){
+            throw new RuntimeException("Failed to delete board with writer: " + writer);
         }
     }
 

--- a/src/main/java/HomePage/service/ReviewBoardService.java
+++ b/src/main/java/HomePage/service/ReviewBoardService.java
@@ -51,7 +51,7 @@ public class ReviewBoardService implements BoardService<ReviewBoard>{
     @Override
     public void deleteBoard(Long id) {
         ReviewBoard reviewBoard = getBoardById(id);
-        if (!reviewBoardRepository.deleteByWriter(reviewBoard.getWriter())) {
+        if (!reviewBoardRepository.deleteById(reviewBoard.getId())) {
             throw new RuntimeException("Failed to delete board with id: " + id);
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,8 +31,10 @@ spring.security.oauth2.client.provider.naver.token-uri = https://nid.naver.com/o
 spring.security.oauth2.client.provider.naver.user-info-uri = https://openapi.naver.com/v1/nid/me
 spring.security.oauth2.client.provider.naver.user-name-attribute = response
 
+spring.mvc.hiddenmethod.filter.enabled=true
 
 spring.thymeleaf.prefix=classpath:/templates/
+
 communityBoard.page-size=10
 reviewBoard.page-size=20
 jwt.secret = "COS"

--- a/src/main/resources/templates/board/boardEditView.html
+++ b/src/main/resources/templates/board/boardEditView.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>글 작성</title>
+    <title>글 수정</title>
     <link rel="stylesheet" type="text/css" th:href="@{/css/navBarStyle.css}">
     <link rel="stylesheet" type="text/css" th:href="@{/css/communityBoardWriteFormStyle.css}">
 </head>
@@ -11,26 +11,22 @@
     <header th:replace="~{fragments/navBar :: navBar}"></header>
     <div class="write-form">
         <div class="form-header">
-            <h2>게시글 작성</h2>
+            <h2>게시글 수정</h2>
             <button class="btn btn-secondary">국 최신순</button>
         </div>
-        <form th:action="@{/api/v1/community/submit}" th:object="${communityBoardWriteForm}" method="post">
+        <form th:action="@{/api/v1/community/{id}/edit(id=${article.id})}" method="post">
+            <input type="hidden" name="_method" value="put" />
+            
             <input type="text" name="title" placeholder="제목을 입력하세요" th:value="${article.title}">
             <div class="error-message" th:if="${valid_title != null}" th:text="${valid_title}"></div>
-
-            <div class="tag-input">
-                <span class="tag">태그1</span>
-                <span class="tag">태그2</span>
-                <input type="text" placeholder="태그를 입력하세요">
-            </div>
-
-            <textarea name="content" placeholder="내용을 입력하세요" th:value="${article.content}"></textarea>
+            
+            <textarea name="content" placeholder="내용을 입력하세요" th:text="${article.content}"></textarea>
             <div class="error-message" th:if="${valid_content != null}" th:text="${valid_content}"></div>
-
+            
             <div class="submit-button">
-                <button type="submit" class="btn btn-primary">작성하기</button>
+                <button type="submit" class="btn btn-primary">수정하기</button>
             </div>
         </form>
-    </div>
+    </div>  
 </body>
 </html>

--- a/src/main/resources/templates/board/boardViewDetail.html
+++ b/src/main/resources/templates/board/boardViewDetail.html
@@ -27,8 +27,13 @@
             </div>
             <div th:with="loggedInUsername=${#authentication.principal instanceof T(HomePage.config.auth.PrincipalDetails) ? #authentication.principal.username : 'anonymousUser'}">
                 <div th:if="${loggedInUsername == article.writer}" class="article-setting">
-                    <button type="button" class="editBtn">수정</button>
-                    <button type="button" class="deleteBtn">삭제</button>
+                    <form th:action="@{/api/v1/community/{id}/editForm(id=${article.id})}">
+                        <button type="submit" class="editBtn">수정</button>
+                    </form>
+                    <form th:action="@{/api/v1/community/{id}/delete(id=${article.id})}" method="post">
+                        <input type="hidden" name="_method" value="delete" />
+                        <button type="sumbit" class="deleteBtn">삭제</button>
+                    </form>
                 </div>
             </div>
             </div>


### PR DESCRIPTION
* 게시글 수정 
세부 사항 수정 버튼 클릭 시 board.writer와 username 비교 후, editFormView를 보여줌.
빈 칸 입력시 그림과 같이 서버에서 로직을 거친 후 다시 렌더링함.
![image](https://github.com/user-attachments/assets/c4e96555-2c6d-4c87-b2e4-3a84dc477a43)

* 게시글 삭제
ex) 14번 게시글 삭제
![image](https://github.com/user-attachments/assets/4c1b9848-e68f-4508-b636-cc4e47ef37ed)

14번 게시글 삭제 전
![image](https://github.com/user-attachments/assets/aa8be6ee-0776-49d4-aed6-3504f30c3d6f)

14번 게시글의 댓글들 삭제 전
![image](https://github.com/user-attachments/assets/7e6fba6f-99c5-49e4-8393-a9e7fcea8ec7)

14번 게시글 삭제 후
![image](https://github.com/user-attachments/assets/f03c27b8-c342-44ca-9943-80317dc56768)

14번 게시글의 댓글 삭제 후
![image](https://github.com/user-attachments/assets/8d631a1c-ca09-40a5-8983-54828e722e2b)

@Transactional 설정

![image](https://github.com/user-attachments/assets/083d7c45-dfc4-4109-a781-adc4aee3ce13)


Todo: 조회수 갱신과 동시에 조회순으로 게시글 목록 정렬, 추천과 비추천 기능 구현