### PR TITLE
[test] : CommunityBoardRepository 단위 테스트 추가 및 기능 개선

### DIFF
--- a/src/main/java/HomePage/repository/BoardRepository.java
+++ b/src/main/java/HomePage/repository/BoardRepository.java
@@ -16,13 +16,13 @@ public interface BoardRepository<T extends Board>{
     boolean deleteById(Long id);
 
     Optional<T> selectById(Long id);
-    Optional<T> selectByTitle(String title);
-    Optional<T> selectByWriter(String writer);
+    List<T> selectByTitle(String title);
+    List<T> selectByWriter(String writer);
 
     List<T> selectAll();
 
-    int incrementViews(Long id);
-    int updateCommentCnt(Long id, int commentCnt);
+    boolean incrementViews(Long id);
+    boolean updateCommentCnt(Long id, int commentCnt);
 
     void setTableName(String tableName);
 }

--- a/src/main/java/HomePage/repository/CommentRepository.java
+++ b/src/main/java/HomePage/repository/CommentRepository.java
@@ -15,4 +15,5 @@ public interface CommentRepository <T extends Comment> {
     List<T> selectById(Long id);
     Optional<T> findCommentById(Long commentId);
     int countByBoardId(Long boardId);
+    void setTableName(String tableName);
 }

--- a/src/main/java/HomePage/repository/JdbcTemplateReviewBoardRepository.java
+++ b/src/main/java/HomePage/repository/JdbcTemplateReviewBoardRepository.java
@@ -85,15 +85,15 @@ public class JdbcTemplateReviewBoardRepository implements BoardRepository<Review
     }
 
     @Override
-    public Optional<ReviewBoard> selectByTitle(String title) {
+    public List<ReviewBoard> selectByTitle(String title) {
         List<ReviewBoard> result = jdbcTemplate.query("select * security.reviewBoard where title = ?", reviewBoardRowMapper(), title);
-        return result.stream().findAny();
+        return result;
     }
 
     @Override
-    public Optional<ReviewBoard> selectByWriter(String writer) {
+    public List<ReviewBoard> selectByWriter(String writer) {
         List<ReviewBoard> result = jdbcTemplate.query("select * security.reviewBoard where writer = ?", reviewBoardRowMapper(), writer);
-        return result.stream().findAny();
+        return result;
     }
 
     @Override
@@ -101,13 +101,13 @@ public class JdbcTemplateReviewBoardRepository implements BoardRepository<Review
         return jdbcTemplate.query("select * from security.reviewBoard", reviewBoardRowMapper());
     }
     @Override
-    public int incrementViews(Long id) {
-        return 0;
+    public boolean incrementViews(Long id) {
+        return false;
     }
 
     @Override
-    public int updateCommentCnt(Long id, int commentCnt) {
-        return 0;
+    public boolean updateCommentCnt(Long id, int commentCnt) {
+        return false;
     }
 
     @Override

--- a/src/main/java/HomePage/service/CommentService.java
+++ b/src/main/java/HomePage/service/CommentService.java
@@ -17,5 +17,5 @@ public interface CommentService <T extends Comment> {
     List<T> getAllComments();
 
     int countByBoardId(Long id);
-    int incrementCommentCnt(Long id, int commentCnt);
+    boolean incrementCommentCnt(Long id, int commentCnt);
 }

--- a/src/main/java/HomePage/service/CommunityBoardService.java
+++ b/src/main/java/HomePage/service/CommunityBoardService.java
@@ -103,16 +103,12 @@ public class CommunityBoardService implements BoardService<CommunityBoard>{
 
     @Override
     public List<CommunityBoard> searchBoardsByTitle(String title) {
-        return communityBoardRepository.selectByTitle(title)
-                .map(List::of)
-                .orElse(List.of());
+        return communityBoardRepository.selectByTitle(title);
     }
 
     @Override
     public List<CommunityBoard> searchBoardsByWriter(String writer) {
-        return communityBoardRepository.selectByWriter(writer)
-                .map(List::of)
-                .orElse(List.of());
+        return communityBoardRepository.selectByWriter(writer);
     }
 
     @Override
@@ -130,9 +126,9 @@ public class CommunityBoardService implements BoardService<CommunityBoard>{
 
     @Override
     public void incrementViews(Long id){
-        int rowsAffected = communityBoardRepository.incrementViews(id);
-        if(rowsAffected != 1){
-            throw new IllegalStateException("Expected 1 row to be updated, but got " + rowsAffected);
+        boolean rowsAffected = communityBoardRepository.incrementViews(id);
+        if(rowsAffected != true){
+            throw new IllegalStateException("Expected 1 row to be updated, but got ");
         }
     }
 

--- a/src/main/java/HomePage/service/CommunityCommentService.java
+++ b/src/main/java/HomePage/service/CommunityCommentService.java
@@ -41,7 +41,7 @@ public class CommunityCommentService implements CommentService<CommunityComment>
         return commentRepository.countByBoardId(BoardId);
     }
     @Override
-    public int incrementCommentCnt(Long id, int commentCnt){
+    public boolean incrementCommentCnt(Long id, int commentCnt){
         return boardRepository.updateCommentCnt(id, commentCnt);
     }
 

--- a/src/main/java/HomePage/service/ReviewBoardService.java
+++ b/src/main/java/HomePage/service/ReviewBoardService.java
@@ -57,16 +57,13 @@ public class ReviewBoardService implements BoardService<ReviewBoard>{
 
     @Override
     public List<ReviewBoard> searchBoardsByTitle(String title) {
-        return reviewBoardRepository.selectByTitle(title)
-                        .map(List::of)
-                        .orElse(List.of());
+        return reviewBoardRepository.selectByTitle(title);
     }
 
     @Override
     public List<ReviewBoard> searchBoardsByWriter(String writer) {
-        return reviewBoardRepository.selectByWriter(writer)
-                        .map(List::of)
-                        .orElse(List.of());
+        return reviewBoardRepository.selectByWriter(writer);
+
     }
 
     @Override

--- a/src/test/java/HomePage/repository/JdbcTemplateCommunityBoardRepositoryTest.java
+++ b/src/test/java/HomePage/repository/JdbcTemplateCommunityBoardRepositoryTest.java
@@ -1,61 +1,496 @@
 package HomePage.repository;
 
+import HomePage.domain.model.CommunityBoard;
+import HomePage.domain.model.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
 class JdbcTemplateCommunityBoardRepositoryTest {
+    @Autowired
+    BoardRepository<CommunityBoard> boardRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    DataSource dataSource;
 
+    private JdbcTemplate jdbcTemplate;
+    @BeforeEach
+    void setUp() {
+       // 테스트 시작 전 테이블 비우기
+       this.jdbcTemplate = new JdbcTemplate(dataSource);
+       boardRepository.setTableName("test.community_board");
+       userRepository.setTableName("test.user");
+       cleanUpDatabase();
+    }
+
+    @AfterEach
+    void tearDown(){
+        // 테스트 시작 후 테이블 비우기
+        cleanUpDatabase();
+    }
+    private void cleanUpDatabase() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+        jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 0");
+        try {
+            // 먼저 댓글 삭제
+           jdbcTemplate.execute("DELETE FROM test.community_comment WHERE board_id > 1");
+           // 그 다음 게시글 삭제
+           jdbcTemplate.execute("DELETE FROM test.community_board WHERE board_id > 1");
+        } finally {
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+            jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 1");
+        }
+    }
     @Test
     void save() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("test");
+        board.setContent("testContent");
+        board.setWriter("testUser");
+
+
+        //when : 실행
+        CommunityBoard savedBoard = boardRepository.save(board);
+        //then : 검증
+        assertThat(savedBoard.getId()).isNotNull();
+        assertThat(savedBoard.getRegisterDate()).isNotNull();
+        assertThat(savedBoard.getTitle()).isEqualTo("test");
+        assertThat(savedBoard.getContent()).isEqualTo("testContent");
+        assertThat(savedBoard.getWriter()).isEqualTo("testUser");
 
     }
 
     @Test
     void findPage() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+
+        // 테스트 데이터 생성
+        for (int i = 1; i <= 20; i++) {
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter(user.getUsername());
+            boardRepository.save(board);
+        }
+
+        //when : 실행
+        int offset = 5;
+        int limit = 10;
+        List<CommunityBoard> result = boardRepository.findPage(offset, limit);
+
+        //then : 검증
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(limit);
+
+        // 결과가 최신순으로 정렬되어 있는지 확인
+        for (int i = 0; i < result.size() - 1; i++) {
+            assertThat(result.get(i).getRegisterDate())
+                .isAfterOrEqualTo(result.get(i + 1).getRegisterDate());
+        }
+
+        // offset이 적용되었는지 확인
+        CommunityBoard firstBoard = result.get(0);
+        assertThat(firstBoard.getTitle()).isEqualTo("Test Title " + (20 - offset));
+
+        // limit가 적용되었는지 확인
+        CommunityBoard lastBoard = result.get(result.size() - 1);
+        assertThat(lastBoard.getTitle()).isEqualTo("Test Title " + (20 - (offset + limit - 1)));
     }
 
     @Test
     void findPageOrderByTopView() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+
+        // 테스트 데이터 생성
+        for (int i = 1; i <= 20; i++) {
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter(user.getUsername());
+            board.setViewCnt(i);
+
+            boardRepository.save(board);
+        }
+        //when : 실행
+        int offset = 5;
+        int limit = 10;
+        List<CommunityBoard> result = boardRepository.findPageOrderByTopView(offset, limit);
+
+        //then : 검증
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(limit);
+
+        // 결과가 죄회순으로 정렬되어 있는지 확인
+        for (int i = 0; i < result.size() - 1; i++) {
+            assertThat(result.get(i).getViewCnt())
+                .isGreaterThanOrEqualTo(result.get(i + 1).getViewCnt()); // 내림차순 확인 왼쪽(result.get(i).getViewCnt())값이 오른쪽(result.get(i + 1).getViewCnt()) 값보다 크거나 같은지 비교
+        }
+
+        // offset이 적용되었는지 확인
+        CommunityBoard firstBoard = result.get(0);
+        assertThat(firstBoard.getViewCnt()).isEqualTo(20 - offset);
+
+        // limit가 적용되었는지 확인
+        CommunityBoard lastBoard = result.get(result.size() - 1);
+        assertThat(lastBoard.getViewCnt()).isEqualTo(20 - (offset + limit - 1));
     }
 
     @Test
     void findPageOrderByTopCommentCnt() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        // 테스트 데이터 생성
+        for (int i = 1; i <= 20; i++) {
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter(user.getUsername());
+            board.setCommentCnt(i);  // 댓글 수를 i로 설정
+            boardRepository.save(board);
+        }
+
+        //when : 실행
+        int offset = 5;
+        int limit = 10;
+        List<CommunityBoard> result = boardRepository.findPageOrderByTopCommentCnt(offset, limit);
+
+        //then : 검증
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(limit);
+
+        // 결과가 댓글 수 순으로 정렬되어 있는지 확인
+        for (int i = 0; i < result.size() - 1; i++) {
+            assertThat(result.get(i).getCommentCnt())
+                .isGreaterThanOrEqualTo(result.get(i + 1).getCommentCnt());
+        }
+
+        // offset이 적용되었는지 확인
+        CommunityBoard firstBoard = result.get(0);
+        assertThat(firstBoard.getCommentCnt()).isEqualTo(20 - offset);
+
+        // limit가 적용되었는지 확인
+        CommunityBoard lastBoard = result.get(result.size() - 1);
+        assertThat(lastBoard.getCommentCnt()).isEqualTo(20 - (offset + limit - 1));
     }
 
     @Test
     void count() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        for(int i = 1; i <= 20; i++){
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter(user.getUsername());
+            board.setCommentCnt(i);  // 댓글 수를 i로 설정
+            boardRepository.save(board);
+        }
+        //when : 실행
+        int count = boardRepository.count();
+        //then : 검증
+        assertThat(count).isEqualTo(20);
+
     }
 
     @Test
-    void update() {
+    void update() throws InterruptedException {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Title Before Modification");
+        board.setContent("Content Before Modification");
+        board.setWriter(user.getUsername());
+        CommunityBoard savedBoard = boardRepository.save(board);
+
+        // 수정할 내용 설정
+        savedBoard.setTitle("Modified Title");
+        savedBoard.setContent("Modified Content");
+
+
+        //when : 실행
+        Thread.sleep(1000);
+        boolean isUpdate = boardRepository.update(savedBoard);
+        //then : 검증
+        assertThat(isUpdate).isTrue();
+        // 수정된 게시글 다시 조회
+        Optional<CommunityBoard> updatedBoardOptional = boardRepository.selectById(savedBoard.getId());
+        assertThat(updatedBoardOptional).isPresent();
+
+        CommunityBoard updatedBoard = updatedBoardOptional.get();
+        assertThat(updatedBoard.getTitle()).isEqualTo("Modified Title");
+        assertThat(updatedBoard.getContent()).isEqualTo("Modified Content");
+        assertThat(updatedBoard.getWriter()).isEqualTo(user.getUsername());
+        assertThat(updatedBoard.getUpdateDate()).isNotNull();
+        assertThat(updatedBoard.getUpdateDate()).isAfter(updatedBoard.getRegisterDate());
     }
 
     @Test
     void deleteById() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter(user.getUsername());
+        CommunityBoard savedBoard = boardRepository.save(board);
+        //when : 실행
+        boolean isDelete = boardRepository.deleteById(savedBoard.getId());
+        //then : 검증
+        assertThat(isDelete).isTrue();
+
+        Optional<CommunityBoard> optionalFoundBoard = boardRepository.selectById(savedBoard.getId());
+        assertThat(optionalFoundBoard).isNotPresent();
+
     }
 
     @Test
     void selectById() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter(user.getUsername());
+        CommunityBoard savedBoard = boardRepository.save(board);
+
+        //when : 실행
+        Optional<CommunityBoard> optionalFoundBoard = boardRepository.selectById(savedBoard.getId());
+        //then : 검증
+        assertThat(optionalFoundBoard).isPresent();
+        CommunityBoard foundBoard = optionalFoundBoard.get();
+        assertThat(foundBoard.getTitle()).isEqualTo(board.getTitle());
+        assertThat(foundBoard.getContent()).isEqualTo(board.getContent());
+        assertThat(foundBoard.getWriter()).isEqualTo(board.getWriter());
+
     }
 
     @Test
     void selectByTitle() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        CommunityBoard board1 = new CommunityBoard();
+        board1.setTitle("Test Title 1");
+        board1.setContent("Test Content 1");
+        board1.setWriter(user.getUsername());
+        boardRepository.save(board1);
+
+        CommunityBoard board2 = new CommunityBoard();
+        board2.setTitle("Test Title 2");
+        board2.setContent("Test Content 2");
+        board2.setWriter(user.getUsername());
+        boardRepository.save(board2);
+
+        CommunityBoard board3 = new CommunityBoard();
+        board3.setTitle("Different Title");
+        board3.setContent("Test Content 3");
+        board3.setWriter(user.getUsername());
+        boardRepository.save(board3);
+
+        //when : 실행
+        List<CommunityBoard> foundBoards = boardRepository.selectByTitle("Test");
+
+        //then : 검증
+        assertThat(foundBoards).hasSize(2);
+        assertThat(foundBoards).extracting("title")
+            .containsExactlyInAnyOrder("Test Title 1", "Test Title 2");
     }
 
     @Test
     void selectByWriter() {
+        //given : 준비
+        User user1 = new User();
+        user1.setUsername("user1");
+        user1.setEmail("user1@example.com");
+        user1.setPassword("password");
+        user1.setRoles("ROLE_USER");
+        userRepository.save(user1);
+
+        User user2 = new User();
+        user2.setUsername("user2");
+        user2.setEmail("user2@example.com");
+        user2.setPassword("password");
+        user2.setRoles("ROLE_USER");
+        userRepository.save(user2);
+
+        CommunityBoard board1 = new CommunityBoard();
+        board1.setTitle("Title 1");
+        board1.setContent("Content 1");
+        board1.setWriter(user1.getUsername());
+        boardRepository.save(board1);
+
+        CommunityBoard board2 = new CommunityBoard();
+        board2.setTitle("Title 2");
+        board2.setContent("Content 2");
+        board2.setWriter(user1.getUsername());
+        boardRepository.save(board2);
+
+        CommunityBoard board3 = new CommunityBoard();
+        board3.setTitle("Title 3");
+        board3.setContent("Content 3");
+        board3.setWriter(user2.getUsername());
+        boardRepository.save(board3);
+
+        //when : 실행
+        List<CommunityBoard> foundBoards = boardRepository.selectByWriter(user1.getUsername());
+
+        //then : 검증
+        assertThat(foundBoards).hasSize(2);
+        assertThat(foundBoards).extracting("writer")
+            .containsOnly(user1.getUsername());
     }
 
     @Test
     void selectAll() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        int boardCount = 5;
+        for (int i = 0; i < boardCount; i++) {
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Title " + i);
+            board.setContent("Content " + i);
+            board.setWriter(user.getUsername());
+            boardRepository.save(board);
+        }
+
+        //when : 실행
+        List<CommunityBoard> allBoards = boardRepository.selectAll();
+
+        //then : 검증
+        assertThat(allBoards).hasSize(boardCount);
     }
 
     @Test
     void incrementViews() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter(user.getUsername());
+        CommunityBoard savedBoard = boardRepository.save(board);
+        int initialViews = savedBoard.getViewCnt();
+
+        //when : 실행
+        boolean result = boardRepository.incrementViews(savedBoard.getId());
+
+        //then : 검증
+        assertThat(result).isTrue();
+        Optional<CommunityBoard> updatedBoardOptional = boardRepository.selectById(savedBoard.getId());
+        assertThat(updatedBoardOptional).isPresent();
+        CommunityBoard updatedBoard = updatedBoardOptional.get();
+        assertThat(updatedBoard.getViewCnt()).isEqualTo(initialViews + 1);
     }
 
     @Test
     void updateCommentCnt() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("test@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+        userRepository.save(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter(user.getUsername());
+        CommunityBoard savedBoard = boardRepository.save(board);
+        int initialCommentCnt = savedBoard.getCommentCnt();
+        int increment = 2;
+
+        //when : 실행
+        boolean result = boardRepository.updateCommentCnt(savedBoard.getId(), increment);
+
+        //then : 검증
+        assertThat(result).isTrue();
+        Optional<CommunityBoard> updatedBoardOptional = boardRepository.selectById(savedBoard.getId());
+        assertThat(updatedBoardOptional).isPresent();
+        CommunityBoard updatedBoard = updatedBoardOptional.get();
+        assertThat(updatedBoard.getCommentCnt()).isEqualTo(initialCommentCnt + increment);
     }
 }

--- a/src/test/java/HomePage/repository/JdbcTemplateCommunityCommentRepositoryTest.java
+++ b/src/test/java/HomePage/repository/JdbcTemplateCommunityCommentRepositoryTest.java
@@ -1,0 +1,45 @@
+package HomePage.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JdbcTemplateCommunityCommentRepositoryTest {
+
+    @Test
+    void save() {
+
+    }
+
+    @Test
+    void countByBoardId() {
+    }
+
+    @Test
+    void selectAll() {
+    }
+
+    @Test
+    void update() {
+    }
+
+    @Test
+    void findCommentById() {
+    }
+
+    @Test
+    void selectById() {
+    }
+
+    @Test
+    void deleteByWriter() {
+    }
+
+    @Test
+    void deleteByCommentId() {
+    }
+
+    @Test
+    void deleteByBoardId() {
+    }
+}

--- a/src/test/java/HomePage/service/UserServiceTest.java
+++ b/src/test/java/HomePage/service/UserServiceTest.java
@@ -229,7 +229,7 @@ class UserServiceTest {
             assertThat(expectedUsernames).contains(user.getUsername());
             assertThat(expectedEmails).contains(user.getEmail());
             assertThat(user.getRoles()).isEqualTo("ROLE_USER");
-        }
+        }   
     }
 
     @Test


### PR DESCRIPTION
- selectById, selectByTitle, selectByWriter, selectAll 등 CommunityBoardRepository 메서드의 단위 테스트 구현
- incrementViews, updateCommentCnt 메서드에 대한 테스트 케이스 추가
- selectByTitle 메서드 개선: 정확한 일치 대신 LIKE 검색으로 변경하여 부분 일치 검색 가능하도록 수정
- 테스트 데이터 생성 시 new User(), new CommunityBoard()를 사용하여 테스트 간 독립성 강화
- findPage 메서드의 테스트 케이스 수정: 페이지네이션 로직 정확성 검증