### PR TITLE
[test] : CommunityBoardService 통합 테스트 추가 및 기능 개선

### DIFF
--- a/src/main/java/HomePage/controller/IndexController.java
+++ b/src/main/java/HomePage/controller/IndexController.java
@@ -15,4 +15,3 @@ public class IndexController {
         return "index"; // 인덱스 페이지 뷰 이름
     }
 }
-

--- a/src/main/java/HomePage/repository/JdbcTemplateUserRepository.java
+++ b/src/main/java/HomePage/repository/JdbcTemplateUserRepository.java
@@ -61,7 +61,6 @@ public class JdbcTemplateUserRepository implements UserRepository {
     public Optional<User> findByUsername(String username) {
         String sql = String.format("SELECT * FROM %s where username = ?", tableName);
         List<User> result = jdbcTemplate.query(sql, memberRowMapper(), username);
-        System.out.println(result);
         return result.stream().findAny();
     }
 
@@ -75,7 +74,6 @@ public class JdbcTemplateUserRepository implements UserRepository {
     public Optional<User> findByEmail(String email) {
         String sql = String.format("SELECT * FROM %s where email = ?", tableName);
         List<User> result = jdbcTemplate.query(sql, memberRowMapper(), email);
-        System.out.println(result);
         return result.stream().findAny();
     }
 

--- a/src/main/java/HomePage/service/BoardService.java
+++ b/src/main/java/HomePage/service/BoardService.java
@@ -10,7 +10,7 @@ public interface BoardService <T extends Board>{
     Page<T> getTopViewedBoardPage(int pageNumber);
     Page<T> getTopCommentCntBoardPage(int pageNumber);
     T getBoardById(Long id);
-    void saveBoard(T board);
+    Long saveBoard(T board);
     void updateBoard(T board);
     void deleteBoard(Long id);
     List<T> searchBoardsByTitle(String title);

--- a/src/main/java/HomePage/service/CommunityBoardService.java
+++ b/src/main/java/HomePage/service/CommunityBoardService.java
@@ -86,11 +86,12 @@ public class CommunityBoardService implements BoardService<CommunityBoard>{
 
     @Override
     @Transactional
-    public void saveBoard(CommunityBoard board) {
+    public Long saveBoard(CommunityBoard board) {
         try {
-            communityBoardRepository.save(board);
+            CommunityBoard savedBoard = communityBoardRepository.save(board);
+            return savedBoard.getId();
         } catch (Exception e) {
-            throw new RuntimeException("Database connection failed");
+            throw new RuntimeException("Database connection failed", e);
         }
     }
 
@@ -132,8 +133,8 @@ public class CommunityBoardService implements BoardService<CommunityBoard>{
 
     @Transactional
     public CommunityBoard getBoardByIdAndIncrementViews(Long id){
-        CommunityBoard board = getBoardById(id);
         incrementViews(id);
+        CommunityBoard board = getBoardById(id);
         return board;
     }
 

--- a/src/main/java/HomePage/service/ReviewBoardService.java
+++ b/src/main/java/HomePage/service/ReviewBoardService.java
@@ -36,8 +36,9 @@ public class ReviewBoardService implements BoardService<ReviewBoard>{
     }
 
     @Override
-    public void saveBoard(ReviewBoard board) {
-        reviewBoardRepository.save(board);
+    public Long saveBoard(ReviewBoard board) {
+        ReviewBoard savedBoard = reviewBoardRepository.save(board);
+        return savedBoard.getId();
     }
 
     @Override

--- a/src/main/java/HomePage/service/UserService.java
+++ b/src/main/java/HomePage/service/UserService.java
@@ -24,6 +24,11 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
+    public UserService(UserRepository userRepository, BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.userRepository = userRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
     public Long join(User user){
         validateUserFields(user);
         validateEmailFormat(user.getEmail());
@@ -42,7 +47,6 @@ public class UserService {
         if (user.getPassword() == null || user.getPassword().trim().isEmpty()) {
             throw new IllegalArgumentException("비밀번호가 필요합니다.");
         }
-        // 추가적인 필드 검증 로직을 여기에 구현할 수 있습니다.
     }
     private void validateEmailFormat(String email) {
        if (!isValidEmail(email)) {

--- a/src/test/java/HomePage/service/CommunityBoardServiceIntegrationTest.java
+++ b/src/test/java/HomePage/service/CommunityBoardServiceIntegrationTest.java
@@ -1,0 +1,701 @@
+package HomePage.service;
+
+import HomePage.controller.board.form.CommunityBoardWriteForm;
+import HomePage.domain.model.CommunityBoard;
+import HomePage.domain.model.CommunityComment;
+import HomePage.domain.model.Page;
+import HomePage.domain.model.User;
+import HomePage.repository.BoardRepository;
+import HomePage.repository.CommentRepository;
+import HomePage.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+
+import javax.sql.DataSource;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(properties = {"communityBoard.page-size=10"})
+class CommunityBoardServiceIntegrationTest {
+    @Autowired
+    CommunityBoardService boardService;
+    @Autowired
+    BoardRepository<CommunityBoard> boardRepository;
+    @Autowired
+    CommunityCommentService commentService;
+    @Autowired
+    CommentRepository<CommunityComment> commentRepository;
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    DataSource dataSource;
+
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 시작 전 테이블 비우기
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+
+        boardRepository.setTableName("test.community_board");
+        userRepository.setTableName("test.user");
+        commentRepository.setTableName("test.community_comment");
+        cleanUpDatabase();
+    }
+
+    @AfterEach
+    void tearDown(){
+        // 테스트 시작 후 테이블 비우기
+        cleanUpDatabase();
+    }
+    private void cleanUpDatabase() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+        jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 0");
+        try {
+            jdbcTemplate.execute("DELETE FROM test.user where id > 1");
+            jdbcTemplate.execute("DELETE FROM test.community_board where board_id > 1");
+            jdbcTemplate.execute("DELETE FROM test.community_comment where comment_id > 1");
+        } finally {
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+            jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 1");
+        }
+    }
+    @Test
+    void validateCommunityForm_Success() {
+        //given : 준비
+        CommunityBoardWriteForm form =  new CommunityBoardWriteForm();
+        form.setTitle("Valid Test");
+        form.setContent("Valid Content");
+
+        Errors errors = new BeanPropertyBindingResult(form, "communityBoardWriteForm");
+        //when : 실행
+        Map<String, String> validatorResult = boardService.validateCommunityForm(errors);
+        //then : 검증
+        assertThat(validatorResult).isEmpty();
+    }
+    @Test
+    void validateCommunityForm_EmptyTitle() {
+        //given : 준비
+        CommunityBoardWriteForm form = new CommunityBoardWriteForm();
+        form.setTitle("");
+        form.setContent("Valid Content");
+
+        Errors errors = new BeanPropertyBindingResult(form, "communityBoardWriteForm");
+        if (form.getTitle() == null || form.getTitle().trim().isEmpty()) {
+              errors.rejectValue("title", "NotBlank", "제목을 입력해주세요.");
+        }
+        //when : 실행
+        Map<String, String> validatorResult = boardService.validateCommunityForm(errors);
+        //then : 검증
+        assertThat(validatorResult).isNotEmpty();
+        assertThat(validatorResult).containsKey("valid_title");
+        assertThat(validatorResult.get("valid_title")).isEqualTo("제목을 입력해주세요.");
+    }
+    @Test
+    void validateCommunityForm_EmptyContent() {
+        //given : 준비
+        CommunityBoardWriteForm form = new CommunityBoardWriteForm();
+        form.setTitle("Valid Title");
+        form.setContent("");
+
+        Errors errors = new BeanPropertyBindingResult(form, "communityBoardWriteForm");
+        if (form.getContent() == null || form.getContent().trim().isEmpty()) {
+              errors.rejectValue("content", "NotBlank", "내용을 입력해주세요.");
+        }
+        //when : 실행
+        Map<String, String> validatorResult = boardService.validateCommunityForm(errors);
+        //then : 검증
+        assertThat(validatorResult).isNotEmpty();
+        assertThat(validatorResult).containsKey("valid_content");
+        assertThat(validatorResult.get("valid_content")).isEqualTo("내용을 입력해주세요.");
+    }
+
+
+    @Test
+    void getBoardPage_Success() {
+        //given : 준비
+        int pageNumber = 1;
+        int pageSize = 10; // 서비스에 정의된 pageSize와 동일함.
+        int totalBoards = 100;
+        int totalPages = (int) Math.ceil((double) totalBoards / pageSize);
+
+        //100명의 사용자 가입
+        for(int i = 0; i < 100; i++){
+            User user = new User();
+            user.setUsername("TestWriter " + i);
+            user.setEmail("Test" + i +"@gmail.com");
+            user.setPassword("test" + i);
+            user.setRoles("ROLE_USER");
+            userService.join(user);
+        }
+
+        // 게시판 저장하기
+        for(int i = 0; i < totalBoards; i++){
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter("TestWriter " + i); // 실제 존재하는 사용자
+            boardService.saveBoard(board);
+        }
+        //when : 실행
+        Page<CommunityBoard> result = boardService.getBoardPage(pageNumber);
+        //then : 검증
+        assertThat(result).isNotNull();
+        assertThat(result.getCurrentPage()).isEqualTo(pageNumber);
+        assertThat(result.getTotalPages()).isEqualTo(totalPages);
+        assertThat(result.getPageSize()).isEqualTo(pageSize);
+
+        for (int i = 0; i < pageSize; i++) {
+           CommunityBoard savedBoard = result.getContent().get(i);
+           assertThat(savedBoard.getTitle()).isEqualTo("Test Title " + (99 - i));
+           assertThat(savedBoard.getContent()).isEqualTo("Test Content " + (99 - i));
+           assertThat(savedBoard.getWriter()).isEqualTo("TestWriter " + (99 - i));
+        }
+    }
+    @Test
+    void getBoardPage_InvalidPageNumber() {
+        //given : 준비
+        int invalidPageNumber = 0; // 잘못된 0번 페이지 번호
+        int pageSize = 10; // 서비스에 정의된 pageSize와 동일함.
+        int totalBoards = 100;
+        int totalPages = (int) Math.ceil((double) totalBoards / pageSize);
+
+        //100명의 사용자 가입
+        for(int i = 0; i < 100; i++){
+            User user = new User();
+            user.setUsername("TestWriter " + i);
+            user.setEmail("Test" + i +"@gmail.com");
+            user.setPassword("test" + i);
+            user.setRoles("ROLE_USER");
+            userService.join(user);
+        }
+
+        // 게시판 저장하기
+        for(int i = 0; i < totalBoards; i++){
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter("TestWriter " + i); // 실제 존재하는 사용자
+            boardService.saveBoard(board);
+        }
+        //when & then: 실행 및 검증
+        assertThatThrownBy(() -> boardService.getBoardPage(invalidPageNumber))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Page number must be greater than 0");
+    }
+
+    @Test
+    void getTopViewedBoardPage() {
+        //given : 준비
+        int pageNumber = 1;
+        int pageSize = 10; // 서비스에 정의된 pageSize와 동일함.
+        int totalBoards = 100;
+        int totalPages = (int) Math.ceil((double) totalBoards / pageSize);
+
+        //100명의 사용자 가입
+        for(int i = 0; i < 100; i++){
+            User user = new User();
+            user.setUsername("TestWriter " + i);
+            user.setEmail("Test" + i +"@gmail.com");
+            user.setPassword("test" + i);
+            user.setRoles("ROLE_USER");
+            userService.join(user);
+        }
+
+        // 게시판 저장하기
+        for(int i = 0; i < totalBoards; i++){
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter("TestWriter " + i); // 실제 존재하는 사용자
+            board.setViewCnt(i);
+            boardService.saveBoard(board);
+        }
+        //when : 실행
+        Page<CommunityBoard> result = boardService.getTopViewedBoardPage(pageNumber);
+        // 조회수 내림차순으로 정렬
+        result.getContent().sort(Comparator.comparing(CommunityBoard::getViewCnt).reversed());
+        //then : 검증
+        assertThat(result).isNotNull();
+        assertThat(result.getCurrentPage()).isEqualTo(pageNumber);
+        assertThat(result.getTotalPages()).isEqualTo(totalPages);
+        assertThat(result.getPageSize()).isEqualTo(pageSize);
+        // 조회수 내림차순 정렬 확인
+        for (int i = 0; i < pageSize - 1; i++) {
+            assertThat(result.getContent().get(i).getViewCnt())
+                .isGreaterThanOrEqualTo(result.getContent().get(i + 1).getViewCnt());
+        }
+    }
+
+    @Test
+    void getTopCommentCntBoardPage() {
+        //given : 준비
+        int pageNumber = 1;
+        int pageSize = 10; // 서비스에 정의된 pageSize와 동일함.
+        int totalBoards = 100;
+        int totalPages = (int) Math.ceil((double) totalBoards / pageSize);
+
+        //100명의 사용자 가입
+        for(int i = 0; i < 100; i++){
+            User user = new User();
+            user.setUsername("TestWriter " + i);
+            user.setEmail("Test" + i +"@gmail.com");
+            user.setPassword("test" + i);
+            user.setRoles("ROLE_USER");
+            userService.join(user);
+        }
+
+        // 게시판 저장하기
+        for(int i = 0; i < totalBoards; i++){
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter("TestWriter " + i); // 실제 존재하는 사용자
+            board.setViewCnt(i);
+            boardService.saveBoard(board);
+        }
+        //when : 실행
+        Page<CommunityBoard> result = boardService.getTopCommentCntBoardPage(pageNumber);
+        // 댓글 순으로 내림차순 정렬
+        result.getContent().sort(Comparator.comparing(CommunityBoard::getCommentCnt).reversed());
+        //then : 검증
+        assertThat(result).isNotNull();
+        assertThat(result.getCurrentPage()).isEqualTo(pageNumber);
+        assertThat(result.getTotalPages()).isEqualTo(totalPages);
+        assertThat(result.getPageSize()).isEqualTo(pageSize);
+
+        // 조회수 내림차순 정렬 확인
+        for (int i = 0; i < pageSize - 1; i++) {
+            assertThat(result.getContent().get(i).getCommentCnt())
+                .isGreaterThanOrEqualTo(result.getContent().get(i + 1).getCommentCnt());
+        }
+
+    }
+
+    @Test
+    void getBoardById_ExistingBoard() {
+        //given : 준비
+        int totalBoards = 100; // 100개의 게시판
+
+        //100명의 사용자 가입
+        for(int i = 0; i < 100; i++){
+            User user = new User();
+            user.setUsername("TestWriter " + i);
+            user.setEmail("Test" + i +"@gmail.com");
+            user.setPassword("test" + i);
+            user.setRoles("ROLE_USER");
+            userService.join(user);
+        }
+
+        // 게시판 저장하기
+        for(int i = 0; i < totalBoards; i++){
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Test Title " + i);
+            board.setContent("Test Content " + i);
+            board.setWriter("TestWriter " + i); // 실제 존재하는 사용자
+            board.setViewCnt(i);
+            boardService.saveBoard(board);
+        }
+
+        // 모든 게시글 불러오기
+        List<CommunityBoard> allBoards = boardService.getAllBoards();
+        //when & then : 실행 및 검증
+        for (CommunityBoard board : allBoards){
+            Long savedBoardId = board.getId();
+
+            CommunityBoard result = boardService.getBoardById(savedBoardId);
+            assertThat(result.getId()).isEqualTo(savedBoardId);
+            assertThat(result.getTitle()).isEqualTo(board.getTitle());
+            assertThat(result.getContent()).isEqualTo(board.getContent());
+        }
+
+    }
+    @Test
+    void getBoardById_NonExistingBoard() {
+        //given : 준비
+        Long nonExistingBoardId = 1L;
+        //when & then : 실행 및 검증
+        assertThatThrownBy(() -> boardService.getBoardById(nonExistingBoardId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Board not found with id: " + nonExistingBoardId);
+    }
+
+
+    @Test
+    void saveBoard_Success() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testWriter");
+        user.setEmail("test@gmail.com");
+        user.setPassword("testPassword");
+        user.setRoles("ROLE_USER");
+        // 게시글 작성을 위한 유저 가입
+        userService.join(user);
+
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter("testWriter");
+        //when : 실행
+        boardService.saveBoard(board);
+
+        // then: 검증
+        List<CommunityBoard> savedBoards = boardService.getAllBoards();
+        assertThat(savedBoards).isNotEmpty();
+        CommunityBoard savedBoard = savedBoards.get(0);
+        assertThat(savedBoard.getTitle()).isEqualTo("Test Title");
+        assertThat(savedBoard.getContent()).isEqualTo("Test Content");
+        assertThat(savedBoard.getWriter()).isEqualTo("testWriter");
+    }
+    @Test
+    void saveBoard_Failure() {
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter("testWriter");
+
+        assertThatThrownBy(() -> boardService.saveBoard(board))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Database connection failed");
+
+    }
+    @Test
+    void updateBoard_Success() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testWriter");
+        user.setEmail("test@gmail.com");
+        user.setPassword("testPassword");
+        user.setRoles("ROLE_USER");
+        // 게시글 작성을 위한 유저 가입
+        userService.join(user);
+
+        CommunityBoard existingBoard = new CommunityBoard();
+        existingBoard.setTitle("Original Title");
+        existingBoard.setContent("Original Content");
+        existingBoard.setWriter("testWriter");
+
+        // saveBoard가 CommunityBoard를 반환한다고 가정
+        Long savedBoardId = boardService.saveBoard(existingBoard);
+
+        // 업데이트할 내용 설정
+        CommunityBoard targetBoard = new CommunityBoard();
+        targetBoard.setId(savedBoardId);
+        targetBoard.setTitle("Updated Title");
+        targetBoard.setContent("Updated Content");
+        targetBoard.setWriter("testWriter");  // writer는 변경하지 않음
+
+        // when : 실행
+        boardService.updateBoard(targetBoard);
+
+        // then : 검증
+        CommunityBoard updatedBoard = boardService.getBoardById(savedBoardId);
+
+        assertThat(updatedBoard.getTitle()).isEqualTo("Updated Title");
+        assertThat(updatedBoard.getContent()).isEqualTo("Updated Content");
+        assertThat(updatedBoard.getWriter()).isEqualTo("testWriter");
+
+        // 원본 게시글과 비교
+        assertThat(updatedBoard.getTitle()).isNotEqualTo(existingBoard.getTitle());
+        assertThat(updatedBoard.getContent()).isNotEqualTo(existingBoard.getContent());
+        assertThat(updatedBoard.getWriter()).isEqualTo(existingBoard.getWriter());
+    }
+    @Test
+    void updateBoard_Failure() {
+        CommunityBoard nonExistentBoard = new CommunityBoard();
+        Long nonExistentBoardId = 100L;
+        nonExistentBoard.setId(nonExistentBoardId);
+        nonExistentBoard.setTitle("Updated Title");
+        nonExistentBoard.setContent("Updated Content");
+
+        // when & then
+        assertThatThrownBy(() -> boardService.updateBoard(nonExistentBoard))
+            .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to update board with id: " + nonExistentBoard.getId());
+    }
+
+    @Test
+    void deleteBoard_Success() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testWriter");
+        user.setEmail("test@gmail.com");
+        user.setPassword("testPassword");
+        user.setRoles("ROLE_USER");
+        userService.join(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter("testWriter");
+        Long savedBoardId = boardService.saveBoard(board);
+
+        //when : 실행
+        assertThatCode(() -> boardService.deleteBoard(savedBoardId))
+                .doesNotThrowAnyException();
+        //then : 검증
+        assertThatThrownBy(() -> boardService.getBoardById(savedBoardId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Board not found with id: " + savedBoardId);
+    }
+    @Test
+    void deleteBoard_failure_case() {
+        // given : 준비
+            Long nonExistentBoardId = 9999L;
+
+        // when & then : 실행 및 검증
+        assertThatThrownBy(() -> boardService.deleteBoard(nonExistentBoardId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to delete board with board_id: " + nonExistentBoardId);
+
+    }
+//    @Test
+//    void deleteBoard_failure_comment_case() {
+//        // given : 준비
+//        User user = new User();
+//        user.setUsername("testWriter");
+//        user.setEmail("test@gmail.com");
+//        user.setPassword("testPassword");
+//        user.setRoles("ROLE_USER");
+//        userService.join(user);
+//
+//        CommunityBoard board = new CommunityBoard();
+//        board.setTitle("Test Title");
+//        board.setContent("Test Content");
+//        board.setWriter("testWriter");
+//        Long savedBoardId = boardService.saveBoard(board);
+//
+//        // when & then : 실행 및 검증
+//        assertThatThrownBy(() -> boardService.deleteBoard(savedBoardId))
+//                .isInstanceOf(RuntimeException.class)
+//                .hasMessageContaining("Failed to delete comments for board with id: " + savedBoardId);
+//
+//        // 게시글이 삭제되지 않았음을 확인
+//        assertThat(boardService.getBoardById(savedBoardId)).isNotNull();
+//    }
+    @Test
+    void searchBoardsByTitle_Success() {
+        // given : 준비
+        User user = new User();
+        user.setUsername("testWriter");
+        user.setEmail("test@gmail.com");
+        user.setPassword("testPassword");
+        user.setRoles("ROLE_USER");
+        userService.join(user);
+
+        CommunityBoard board1 = new CommunityBoard();
+        board1.setTitle("Test Title");
+        board1.setContent("Test Content");
+        board1.setWriter("testWriter");
+        boardService.saveBoard(board1);
+
+        CommunityBoard board2 = new CommunityBoard();
+        board2.setTitle("Another Title");
+        board2.setContent("Another Content");
+        board2.setWriter("testWriter");
+        boardService.saveBoard(board2);
+
+        // when : 실행
+        List<CommunityBoard> searchResult = boardService.searchBoardsByTitle("Test");
+
+        // then : 검증
+        assertThat(searchResult).hasSize(1);
+        assertThat(searchResult.get(0).getTitle()).isEqualTo("Test Title");
+    }
+    @Test
+    void searchBoardsByTitle_NoResult() {
+        // 시나리오: 존재하지 않는 제목으로 게시글 검색
+        // given : 준비
+        String nonExistentTitle = "Non-existent Title";
+
+        // when : 실행
+        List<CommunityBoard> searchResult = boardService.searchBoardsByTitle(nonExistentTitle);
+
+        // then : 검증
+        assertThat(searchResult).isEmpty();
+    }
+
+    @Test
+    void searchBoardsByWriter() {
+        // given : 준비
+        User user1 = new User();
+        user1.setUsername("writer1");
+        user1.setEmail("writer1@gmail.com");
+        user1.setPassword("password");
+        user1.setRoles("ROLE_USER");
+        userService.join(user1);
+
+        User user2 = new User();
+        user2.setUsername("writer2");
+        user2.setEmail("writer2@gmail.com");
+        user2.setPassword("password");
+        user2.setRoles("ROLE_USER");
+        userService.join(user2);
+
+        CommunityBoard board1 = new CommunityBoard();
+        board1.setTitle("Title 1");
+        board1.setContent("Content 1");
+        board1.setWriter("writer1");
+        boardService.saveBoard(board1);
+
+        CommunityBoard board2 = new CommunityBoard();
+        board2.setTitle("Title 2");
+        board2.setContent("Content 2");
+        board2.setWriter("writer2");
+        boardService.saveBoard(board2);
+
+        // when : 실행
+        List<CommunityBoard> searchResult = boardService.searchBoardsByWriter("writer1");
+
+        // then : 검증
+        assertThat(searchResult).hasSize(1);
+        assertThat(searchResult.get(0).getWriter()).isEqualTo("writer1");
+    }
+    @Test
+    void searchBoardsByWriter_NoResult() {
+        // 시나리오: 존재하지 않는 작성자로 게시글 검색
+        // given : 준비
+        String nonExistentWriter = "Non-existent Writer";
+
+        // when : 실행
+        List<CommunityBoard> searchResult = boardService.searchBoardsByWriter(nonExistentWriter);
+
+        // then : 검증
+        assertThat(searchResult).isEmpty();
+    }
+
+    @Test
+    void getAllBoards_Success() {
+        // given : 준비
+        User user = new User();
+        user.setUsername("testWriter");
+        user.setEmail("test@gmail.com");
+        user.setPassword("testPassword");
+        user.setRoles("ROLE_USER");
+        userService.join(user);
+
+        int totalBoards = 5;
+        for (int i = 0; i < totalBoards; i++) {
+            CommunityBoard board = new CommunityBoard();
+            board.setTitle("Title " + i);
+            board.setContent("Content " + i);
+            board.setWriter("testWriter");
+            boardService.saveBoard(board);
+        }
+
+        // when : 실행
+        List<CommunityBoard> allBoards = boardService.getAllBoards();
+
+        // then : 검증
+        assertThat(allBoards).hasSize(totalBoards);
+    }
+    @Test
+    void getAllBoards_EmptyResult() {
+        // 시나리오: 게시글이 하나도 없는 경우
+        // given : 준비 (게시글을 추가하지 않음)
+
+        // when : 실행
+        List<CommunityBoard> allBoards = boardService.getAllBoards();
+
+        // then : 검증
+        assertThat(allBoards).isEmpty();
+    }
+
+    @Test
+    void getBoardByIdAndIncrementViews_Success() {
+        // given : 준비
+        User user = new User();
+        user.setUsername("testWriter");
+        user.setEmail("test@gmail.com");
+        user.setPassword("testPassword");
+        user.setRoles("ROLE_USER");
+        userService.join(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter("testWriter");
+        board.setViewCnt(0);
+        Long savedBoardId = boardService.saveBoard(board);
+
+        // when : 실행
+        CommunityBoard retrievedBoard = boardService.getBoardByIdAndIncrementViews(savedBoardId);
+
+        // then : 검증
+        assertThat(retrievedBoard).isNotNull();
+        assertThat(retrievedBoard.getId()).isEqualTo(savedBoardId);
+        assertThat(retrievedBoard.getViewCnt()).isEqualTo(1);  // 조회수가 1 증가했는지 확인
+
+        // 다시 조회하여 조회수가 증가했는지 확인
+        CommunityBoard retrievedBoardAgain = boardService.getBoardByIdAndIncrementViews(savedBoardId);
+        assertThat(retrievedBoardAgain.getViewCnt()).isEqualTo(2);
+    }
+    @Test
+    void getBoardByIdAndIncrementViews_NonExistingBoard() {
+        // 시나리오: 존재하지 않는 게시글 조회 시도
+        // given : 준비
+        Long nonExistingBoardId = 9999L;
+
+        // when & then : 실행 및 검증
+        assertThatThrownBy(() -> boardService.getBoardByIdAndIncrementViews(nonExistingBoardId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Expected 1 row to be updated, but got ");
+    }
+
+    @Test
+    void incrementViews_Success() {
+        // given : 준비
+        User user = new User();
+        user.setUsername("testWriter");
+        user.setEmail("test@gmail.com");
+        user.setPassword("testPassword");
+        user.setRoles("ROLE_USER");
+        userService.join(user);
+
+        CommunityBoard board = new CommunityBoard();
+        board.setTitle("Test Title");
+        board.setContent("Test Content");
+        board.setWriter("testWriter");
+        Long savedBoardId = boardService.saveBoard(board);
+
+        // when : 실행
+        boardService.incrementViews(savedBoardId);
+
+        // then : 검증
+        CommunityBoard retrievedBoard = boardService.getBoardById(savedBoardId);
+        assertThat(retrievedBoard.getViewCnt()).isEqualTo(1);
+
+        // 한 번 더 증가
+        boardService.incrementViews(savedBoardId);
+        retrievedBoard = boardService.getBoardById(savedBoardId);
+        assertThat(retrievedBoard.getViewCnt()).isEqualTo(2);
+    }
+    @Test
+    void incrementViews_NonExistingBoard() {
+        // 시나리오: 존재하지 않는 게시글의 조회수 증가 시도
+        // given : 준비
+        Long nonExistingBoardId = 9999L;
+
+        // when & then : 실행 및 검증
+        assertThatThrownBy(() -> boardService.incrementViews(nonExistingBoardId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Expected 1 row to be updated, but got ");
+    }
+}

--- a/src/test/java/HomePage/service/CommunityBoardServiceTest.java
+++ b/src/test/java/HomePage/service/CommunityBoardServiceTest.java
@@ -35,19 +35,21 @@ class CommunityBoardServiceTest {
 
     @Test
     void validateCommunityForm_Success() {
+        //given : 준비
         CommunityBoardWriteForm form = new CommunityBoardWriteForm();
         form.setTitle("Valid Title");
         form.setContent("Valid Content");
 
         Errors errors = new BeanPropertyBindingResult(form, "communityBoardWriteForm");
-
+        //when : 실행
         Map<String, String> validatorResult = boardService.validateCommunityForm(errors);
-
+        //then : 검증
         assertThat(validatorResult).isEmpty();
     }
 
     @Test
     void validateCommunityForm_EmptyTitle() {
+        //given : 준비
         CommunityBoardWriteForm form = new CommunityBoardWriteForm();
         form.setTitle("");
         form.setContent("Valid Content");
@@ -56,9 +58,9 @@ class CommunityBoardServiceTest {
         if (form.getTitle() == null || form.getTitle().trim().isEmpty()) {
             errors.rejectValue("title", "NotBlank", "제목을 입력해주세요.");
         }
-
+        //when : 실행
         Map<String, String> validatorResult = boardService.validateCommunityForm(errors);
-
+        //then : 검증
         assertThat(validatorResult).isNotEmpty();
         assertThat(validatorResult).containsKey("valid_title");
         assertThat(validatorResult.get("valid_title")).isEqualTo("제목을 입력해주세요.");
@@ -92,7 +94,6 @@ class CommunityBoardServiceTest {
         Page<CommunityBoard> result = boardService.getBoardPage(pageNumber);
         //then : 검증
         assertThat(result).isNotNull();
-        assertThat(result.getContent()).hasSize(pageSize);
         assertThat(result.getCurrentPage()).isEqualTo(pageNumber);
         assertThat(result.getTotalPages()).isEqualTo(totalPages);
         assertThat(result.getPageSize()).isEqualTo(pageSize);
@@ -101,14 +102,14 @@ class CommunityBoardServiceTest {
            CommunityBoard board = result.getContent().get(i);
            assertThat(board.getTitle()).isEqualTo("Test Title " + i);
            assertThat(board.getContent()).isEqualTo("Test Content " + i);
-       }
+        }
 
-       // boardRepository 메서드들이 올바른 파라미터로 호출되었는지 확인
-       verify(boardRepository).count();
-       verify(boardRepository).findPage(eq((pageNumber - 1) * pageSize), eq(pageSize));
+        // boardRepository 메서드들이 올바른 파라미터로 호출되었는지 확인
+        verify(boardRepository).count();
+        verify(boardRepository).findPage(eq((pageNumber - 1) * pageSize), eq(pageSize));
     }
     @Test
-   void getBoardPage_InvalidPageNumber() {
+    void getBoardPage_InvalidPageNumber() {
         // given
         int invalidPageNumber = 0;
 
@@ -124,7 +125,7 @@ class CommunityBoardServiceTest {
         // 리포지토리 메서드가 호출되지 않았는지 확인
         verify(boardRepository, never()).count();
         verify(boardRepository, never()).findPage(anyInt(), anyInt());
-   }
+    }
 
     @Test
     void getTopViewedBoardPage() {

--- a/src/test/java/HomePage/service/UserServiceIntegrationTest.java
+++ b/src/test/java/HomePage/service/UserServiceIntegrationTest.java
@@ -1,81 +1,293 @@
 package HomePage.service;
 
+import HomePage.controller.UserForm;
 import HomePage.domain.model.User;
 import HomePage.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.sql.DataSource;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
-
 class UserServiceIntegrationTest {
+    @Autowired
+    UserService userService;
     @Autowired
     UserRepository userRepository;
     @Autowired
-    UserService userService;
+    BCryptPasswordEncoder passwordEncoder;
+    @Autowired
+    DataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+    @BeforeEach
+    void setUp() {
+        // 테스트 시작 전 테이블 비우기
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        userRepository.setTableName("test.user");
+        cleanUpDatabase();
+    }
+
+    @AfterEach
+    void tearDown(){
+        // 테스트 시작 후 테이블 비우기
+        cleanUpDatabase();
+    }
+    private void cleanUpDatabase() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+        jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 0");
+        try {
+            jdbcTemplate.execute("DELETE FROM test.user where id > 1");
+        } finally {
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+            jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 1");
+        }
+    }
 
     @Test
-    public void 회원가입() throws Exception {
-        //Given
+    void join() {
+        //given : 준비
         User user = new User();
-        user.setUsername("hello");
-        //When
-        Long saveId = userService.join(user);
-        //Then
-        User findUser = userRepository.findById(saveId).get();
-        assertEquals(user.getUsername(), findUser.getUsername());
+        user.setUsername("test");
+        user.setPassword("testPassword");
+        user.setEmail("test@test.com");
+        user.setRoles("ROLE_USER");
+        //when : 실행
+        Long joinedUserId = userService.join(user);
+        //then : 검증
+        User foundUser = userService.findOne(joinedUserId).orElse(null);
+        assertThat(foundUser).isNotNull();
+        assertThat(foundUser.getUsername()).isEqualTo("test");
+        assertThat(foundUser.getEmail()).isEqualTo("test@test.com");
+        assertThat(foundUser.getRoles()).isEqualTo("ROLE_USER");
+        assertThat(foundUser.getPassword()).isNotEmpty();
     }
     @Test
-    public void 중복_회원_예외() throws Exception {
-        //Given
-        // 이름만 중복인 경우
+    void joinWithMissingRequiredField() {
+        //given : 준비
+        User user = new User();
+        user.setEmail("test@test.com");
+        user.setPassword("password");
+        // when & then : 실행 및 검증
+        assertThatThrownBy(() -> userService.join(user))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이름이 필요합니다.");
+    }
+
+    @Test
+    void joinWithInvalidEmail() {
+        //given : 준비
+        User user = new User();
+        user.setUsername("testUser");
+        user.setEmail("invalid-email");
+        user.setPassword("password");
+        // when & then : 실행 및 검증
+        assertThatThrownBy(() -> userService.join(user))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("부정확한 이메일 포멧입니다.");
+    }
+//    @Test
+//    void joinWithWeakPassword() {
+//        //given : 준비
+//        User user = new User();
+//        user.setUsername("testuser");
+//        user.setEmail("test@test.com");
+//        user.setPassword("weak");
+//        //when :& then : 실행 및 검증
+//        assertThatThrownBy(() -> userService.join(user))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessageContaining("Password does not meet complexity requirements");
+//    }
+
+    @Test
+    void joinWithValidEmail() {
+        User user = new User();
+        user.setUsername("testuser");
+        user.setEmail("valid.email@example.com");
+        user.setPassword("password");
+        user.setRoles("ROLE_USER");
+
+        Long joinedUserId = userService.join(user);
+
+        assertThat(joinedUserId).isNotNull();
+        Optional<User> foundUser = userService.findOne(joinedUserId);
+        assertThat(foundUser).isPresent();
+        assertThat(foundUser.get().getEmail()).isEqualTo("valid.email@example.com");
+    }
+
+    @Test
+    void setInvalidRole() {
+        User user = new User();
+        user.setUsername("testuser");
+        user.setEmail("test@test.com");
+        user.setPassword("password");
+        user.setRoles("INVALID_ROLE");
+
+        assertThatThrownBy(() -> userService.join(user))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("타당하지않은 권한입니다.");
+    }
+
+
+    @Test
+    void userFormDto(){
+        //given : 준비
+        UserForm userForm = new UserForm();
+        userForm.setUsername("test");
+        userForm.setPassword("testPassword");
+        userForm.setEmail("test@test.com");
+        //when : 실행
+        User user = userService.userFormDTO(userForm);
+        //then : 검증
+        assertThat(user).isNotNull();
+        assertThat(user.getUsername()).isEqualTo("test");
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(passwordEncoder.matches("testPassword", user.getPassword())).isTrue();
+    }
+
+    @Test
+    void validateDuplicateMember() {
+        //given : 준비(Username 중복 상황)
         User user1 = new User();
-        user1.setUsername("spring");
-        user1.setEmail("tlans20@naver.com");
-        User user2 = new User();
-        user2.setUsername("spring");
-        user2.setEmail("tlans21@naver.com");
+        user1.setUsername("test1");
+        user1.setEmail("test@test.com");
+        user1.setPassword("testPassword");
+        user1.setRoles("ROLE_USER");
 
-        // 이메일이 중복인 경우
-        User user3 = new User();
-        user3.setUsername("simun1");
-        user3.setEmail("tlans21@naver.com");
-        User user4 = new User();
-        user4.setUsername("simun2");
-        user4.setEmail("tlans21@naver.com");
+        User user2 = new User(); // Username 중복
+        user2.setUsername("test1");
+        user2.setEmail("test2@test.com");
+        user2.setPassword("testPassword");
+        user2.setRoles("ROLE_USER");
 
-        //When
-        userService.join(user1);
-        IllegalStateException e1 = assertThrows(IllegalStateException.class,
-                () -> userService.join(user2));//예외가 발생해야 한다.
-        assertThat(e1.getMessage()).isEqualTo("이미 존재하는 이름입니다.");
-        userService.join(user3);
-        IllegalStateException e2 = assertThrows(IllegalStateException.class,
-                () -> userService.join(user4));//예외가 발생해야 한다.
-        assertThat(e2.getMessage()).isEqualTo("이미 존재하는 이메일입니다.");
+        User user3 = new User(); // Email 중복
+        user3.setUsername("test3");
+        user3.setEmail("test@test.com");
+        user3.setPassword("testPassword");
+        user3.setRoles("ROLE_USER");
+
+        userRepository.save(user1);
+        //when & then : 실행 및 검증
+        assertThatThrownBy(() -> userService.validateDuplicateMember(user2))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 존재하는 이름입니다.");
+        assertThatThrownBy(() -> userService.validateDuplicateMember(user3))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 존재하는 이메일입니다.");
+
+
+
     }
 
     @Test
-    public void 로그인(){
-        User registeredUser = new User();
-        registeredUser.setUsername("simunss");
-        registeredUser.setEmail("simun@naver.com");
-        registeredUser.setPassword("1234");
-        userService.join(registeredUser); // 회원 가입
+    void findMembers() {
+        //given: 준비
+        User user1 = new User();
+        user1.setUsername("test1");
+        user1.setEmail("test1@test1.com");
+        user1.setPassword("testPassword");
+        user1.setRoles("ROLE_USER");
 
-        User user = new User();
-        user.setUsername("simunss");
-        user.setEmail("simun@naver.com");
-        user.setPassword("1234");
-        Optional<User> result = userService.authenticateMember(user.getEmail(), user.getPassword());
-        assertThat(user.getUsername()).isEqualTo(result.get().getUsername());
+        User user2 = new User(); // Username 중복
+        user2.setUsername("test2");
+        user2.setEmail("test2@test2.com");
+        user2.setPassword("testPassword");
+        user2.setRoles("ROLE_USER");
+
+        User user3 = new User(); // Email 중복
+        user3.setUsername("test3");
+        user3.setEmail("test3@test3.com");
+        user3.setPassword("testPassword");
+        user3.setRoles("ROLE_USER");
+
+        userService.join(user1);
+        userService.join(user2);
+        userService.join(user3);
+
+        //when : 실행
+        List<User> users = userService.findMembers();
+        //then : 검증
+        assertThat(users).isNotNull();
+        assertThat(users.size()).isEqualTo(3);
+
+        List<String> expectedUsernames = Arrays.asList("test1", "test2", "test3");
+        List<String> expectedEmails = Arrays.asList("test1@test1.com", "test2@test2.com", "test3@test3.com");
+
+        for (User user: users){
+            assertThat(user).isNotNull();
+            assertThat(expectedUsernames).contains(user.getUsername());
+            assertThat(expectedEmails).contains(user.getEmail());
+            assertThat(user.getRoles()).isEqualTo("ROLE_USER");
+        }   
     }
+
+    @Test
+    void findOne() {
+        //given : 준비
+        User user = new User();
+        user.setEmail("test1@test1.com");
+        user.setPassword("testPassword");
+        user.setUsername("test1");
+        user.setRoles("ROLE_USER");
+
+        Long joinedUserId = userService.join(user);
+
+        //when : 실행
+        Optional<User> foundUser = userService.findOne(joinedUserId);
+        //then : 검증
+
+        assertThat(foundUser).isPresent();
+
+        User retrievedUser = foundUser.get();
+
+        assertThat(retrievedUser.getId()).isEqualTo(joinedUserId);
+        assertThat(retrievedUser.getEmail()).isEqualTo("test1@test1.com");
+        assertThat(retrievedUser.getUsername()).isEqualTo("test1");
+        assertThat(retrievedUser.getRoles()).isEqualTo("ROLE_USER");
+
+        // 존재하지 않는 ID로 검색
+        Optional<User> nonExistentUser = userService.findOne(9999L);
+        assertThat(nonExistentUser).isEmpty();
+    }
+
+    @Test
+    void findByUsername() {
+        //given: 준비
+        User user = new User();
+        user.setEmail("test1@test1.com");
+        user.setPassword("testPassword");
+        user.setUsername("test1");
+        user.setRoles("ROLE_USER");
+
+        Long joinedUserId = userService.join(user);
+        //when : 실행
+        Optional<User> foundUser = userService.findByUsername(user.getUsername());
+        //then : 검증
+        assertThat(foundUser).isPresent();
+
+        User retrievedUser = foundUser.get();
+        assertThat(retrievedUser.getId()).isEqualTo(joinedUserId);
+        assertThat(retrievedUser.getEmail()).isEqualTo("test1@test1.com");
+        assertThat(retrievedUser.getUsername()).isEqualTo("test1");
+        assertThat(retrievedUser.getRoles()).isEqualTo("ROLE_USER");
+
+
+        // 존재하지 않는 ID로 검색
+       Optional<User> nonExistentUser = userService.findByUsername("nonExistUsername");
+       assertThat(nonExistentUser).isEmpty();
+    }
+
 }

--- a/src/test/java/HomePage/service/UserServiceTest.java
+++ b/src/test/java/HomePage/service/UserServiceTest.java
@@ -3,289 +3,190 @@ package HomePage.service;
 import HomePage.controller.UserForm;
 import HomePage.domain.model.User;
 import HomePage.repository.UserRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.transaction.annotation.Transactional;
 
-import javax.sql.DataSource;
-
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest
-@Transactional
 class UserServiceTest {
-    @Autowired
-    UserService userService;
-    @Autowired
-    UserRepository userRepository;
-    @Autowired
-    BCryptPasswordEncoder passwordEncoder;
-    @Autowired
-    DataSource dataSource;
-    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    private UserService userService;
+
     @BeforeEach
     void setUp() {
-        // 테스트 시작 전 테이블 비우기
-        this.jdbcTemplate = new JdbcTemplate(dataSource);
-        userRepository.setTableName("test.user");
-        cleanUpDatabase();
-    }
-
-    @AfterEach
-    void tearDown(){
-        // 테스트 시작 후 테이블 비우기
-        cleanUpDatabase();
-    }
-    private void cleanUpDatabase() {
-        jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 0");
-        try {
-            jdbcTemplate.execute("DELETE FROM test.user where id > 1");
-        } finally {
-            jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 1");
-        }
+        MockitoAnnotations.openMocks(this);
+        userService = new UserService(userRepository, passwordEncoder);
     }
 
     @Test
     void join() {
-        //given : 준비
+        // given
         User user = new User();
         user.setUsername("test");
         user.setPassword("testPassword");
         user.setEmail("test@test.com");
         user.setRoles("ROLE_USER");
-        //when : 실행
+
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+               User savedUser = invocation.getArgument(0);
+               savedUser.setId(1L);  // Set an ID to simulate database save
+               return savedUser;
+        });
+        when(userRepository.findByUsername(user.getUsername())).thenReturn(Optional.empty());
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.empty());
+        // when
         Long joinedUserId = userService.join(user);
-        //then : 검증
-        User foundUser = userService.findOne(joinedUserId).orElse(null);
-        assertThat(foundUser).isNotNull();
-        assertThat(foundUser.getUsername()).isEqualTo("test");
-        assertThat(foundUser.getEmail()).isEqualTo("test@test.com");
-        assertThat(foundUser.getRoles()).isEqualTo("ROLE_USER");
-        assertThat(foundUser.getPassword()).isNotEmpty();
+
+        // then
+        assertThat(joinedUserId).isEqualTo(1L);
+        verify(userRepository).save(user);
+        verify(userRepository).findByUsername(user.getUsername());
+        verify(userRepository).findByEmail(user.getEmail());
     }
+
     @Test
     void joinWithMissingRequiredField() {
-        //given : 준비
+        // given
         User user = new User();
         user.setEmail("test@test.com");
         user.setPassword("password");
-        // when & then : 실행 및 검증
+
+        // when & then
         assertThatThrownBy(() -> userService.join(user))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("이름이 필요합니다.");
     }
 
     @Test
-    void joinWithInvalidEmail() {
-        //given : 준비
-        User user = new User();
-        user.setUsername("testUser");
-        user.setEmail("invalid-email");
-        user.setPassword("password");
-        // when & then : 실행 및 검증
-        assertThatThrownBy(() -> userService.join(user))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("부정확한 이메일 포멧입니다.");
-    }
-//    @Test
-//    void joinWithWeakPassword() {
-//        //given : 준비
-//        User user = new User();
-//        user.setUsername("testuser");
-//        user.setEmail("test@test.com");
-//        user.setPassword("weak");
-//        //when :& then : 실행 및 검증
-//        assertThatThrownBy(() -> userService.join(user))
-//                .isInstanceOf(IllegalArgumentException.class)
-//                .hasMessageContaining("Password does not meet complexity requirements");
-//    }
-
-    @Test
-    void joinWithValidEmail() {
-        User user = new User();
-        user.setUsername("testuser");
-        user.setEmail("valid.email@example.com");
-        user.setPassword("password");
-        user.setRoles("ROLE_USER");
-
-        Long joinedUserId = userService.join(user);
-
-        assertThat(joinedUserId).isNotNull();
-        Optional<User> foundUser = userService.findOne(joinedUserId);
-        assertThat(foundUser).isPresent();
-        assertThat(foundUser.get().getEmail()).isEqualTo("valid.email@example.com");
-    }
-
-    @Test
-    void setInvalidRole() {
-        User user = new User();
-        user.setUsername("testuser");
-        user.setEmail("test@test.com");
-        user.setPassword("password");
-        user.setRoles("INVALID_ROLE");
-
-        assertThatThrownBy(() -> userService.join(user))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("타당하지않은 권한입니다.");
-    }
-
-
-    @Test
-    void userFormDto(){
-        //given : 준비
-        UserForm userForm = new UserForm();
-        userForm.setUsername("test");
-        userForm.setPassword("testPassword");
-        userForm.setEmail("test@test.com");
-        //when : 실행
-        User user = userService.userFormDTO(userForm);
-        //then : 검증
-        assertThat(user).isNotNull();
-        assertThat(user.getUsername()).isEqualTo("test");
-        assertThat(user.getEmail()).isEqualTo("test@test.com");
-        assertThat(passwordEncoder.matches("testPassword", user.getPassword())).isTrue();
-    }
-
-    @Test
     void validateDuplicateMember() {
-        //given : 준비(Username 중복 상황)
-        User user1 = new User();
-        user1.setUsername("test1");
-        user1.setEmail("test@test.com");
-        user1.setPassword("testPassword");
-        user1.setRoles("ROLE_USER");
+        // given
+        User user = new User();
+        user.setUsername("test1");
+        user.setEmail("test@test.com");
 
-        User user2 = new User(); // Username 중복
-        user2.setUsername("test1");
-        user2.setEmail("test2@test.com");
-        user2.setPassword("testPassword");
-        user2.setRoles("ROLE_USER");
+        when(userRepository.findByUsername("test1")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(user));
 
-        User user3 = new User(); // Email 중복
-        user3.setUsername("test3");
-        user3.setEmail("test@test.com");
-        user3.setPassword("testPassword");
-        user3.setRoles("ROLE_USER");
+        // when & then
+        User duplicateUsername = new User();
+        duplicateUsername.setUsername("test1");
+        duplicateUsername.setEmail("different@test.com");
 
-        userRepository.save(user1);
-        //when & then : 실행 및 검증
-        assertThatThrownBy(() -> userService.validateDuplicateMember(user2))
+        assertThatThrownBy(() -> userService.validateDuplicateMember(duplicateUsername))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 이름입니다.");
-        assertThatThrownBy(() -> userService.validateDuplicateMember(user3))
+
+        User duplicateEmail = new User();
+        duplicateEmail.setUsername("different");
+        duplicateEmail.setEmail("test@test.com");
+
+        assertThatThrownBy(() -> userService.validateDuplicateMember(duplicateEmail))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 이메일입니다.");
-
-
-
     }
 
     @Test
     void findMembers() {
-        //given: 준비
-        User user1 = new User();
-        user1.setUsername("test1");
-        user1.setEmail("test1@test1.com");
-        user1.setPassword("testPassword");
-        user1.setRoles("ROLE_USER");
+        // given
+        List<User> expectedUsers = new ArrayList<>();
 
-        User user2 = new User(); // Username 중복
-        user2.setUsername("test2");
-        user2.setEmail("test2@test2.com");
-        user2.setPassword("testPassword");
-        user2.setRoles("ROLE_USER");
+        for (int i = 1; i <= 3; i++) {
+            User user = new User();
+            user.setId((long) i);
+            user.setUsername("test" + i);
+            user.setPassword("testPassword" + i);
+            user.setEmail("test" + i + "@test.com");
+            user.setRoles("ROLE_USER");
+            expectedUsers.add(user);
+        }
 
-        User user3 = new User(); // Email 중복
-        user3.setUsername("test3");
-        user3.setEmail("test3@test3.com");
-        user3.setPassword("testPassword");
-        user3.setRoles("ROLE_USER");
+        when(userRepository.findAll()).thenReturn(expectedUsers);
 
-        userService.join(user1);
-        userService.join(user2);
-        userService.join(user3);
-
-        //when : 실행
+        // when
         List<User> users = userService.findMembers();
-        //then : 검증
-        assertThat(users).isNotNull();
-        assertThat(users.size()).isEqualTo(3);
 
-        List<String> expectedUsernames = Arrays.asList("test1", "test2", "test3");
-        List<String> expectedEmails = Arrays.asList("test1@test1.com", "test2@test2.com", "test3@test3.com");
-
-        for (User user: users){
-            assertThat(user).isNotNull();
-            assertThat(expectedUsernames).contains(user.getUsername());
-            assertThat(expectedEmails).contains(user.getEmail());
-            assertThat(user.getRoles()).isEqualTo("ROLE_USER");
-        }   
+        // then
+        assertThat(users).hasSize(3);
+        assertThat(users).containsExactlyElementsOf(expectedUsers);
+        verify(userRepository).findAll();
     }
 
     @Test
     void findOne() {
-        //given : 준비
-        User user = new User();
-        user.setEmail("test1@test1.com");
-        user.setPassword("testPassword");
-        user.setUsername("test1");
-        user.setRoles("ROLE_USER");
+        // given
+        Long userId = 1L;
+        User expectedUser = new User();
+        expectedUser.setId(userId);
+        expectedUser.setUsername("test");
+        expectedUser.setPassword("testPassword");
+        expectedUser.setEmail("test@test.com");
+        expectedUser.setRoles("ROLE_USER");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(expectedUser));
 
-        Long joinedUserId = userService.join(user);
+        // when
+        Optional<User> foundUser = userService.findOne(userId);
 
-        //when : 실행
-        Optional<User> foundUser = userService.findOne(joinedUserId);
-        //then : 검증
-
+        // then
         assertThat(foundUser).isPresent();
-
-        User retrievedUser = foundUser.get();
-
-        assertThat(retrievedUser.getId()).isEqualTo(joinedUserId);
-        assertThat(retrievedUser.getEmail()).isEqualTo("test1@test1.com");
-        assertThat(retrievedUser.getUsername()).isEqualTo("test1");
-        assertThat(retrievedUser.getRoles()).isEqualTo("ROLE_USER");
-
-        // 존재하지 않는 ID로 검색
-        Optional<User> nonExistentUser = userService.findOne(9999L);
-        assertThat(nonExistentUser).isEmpty();
+        assertThat(foundUser.get()).isEqualTo(expectedUser);
+        verify(userRepository).findById(userId);
     }
 
     @Test
     void findByUsername() {
-        //given: 준비
-        User user = new User();
-        user.setEmail("test1@test1.com");
-        user.setPassword("testPassword");
-        user.setUsername("test1");
-        user.setRoles("ROLE_USER");
+        // given
+        String username = "test";
+        Long userId = 1L;
+        User expectedUser = new User();
+        expectedUser.setId(userId);
+        expectedUser.setUsername("test");
+        expectedUser.setPassword("testPassword");
+        expectedUser.setEmail("test@test.com");
+        expectedUser.setRoles("ROLE_USER");
+        when(userRepository.findByUsername(username)).thenReturn(Optional.of(expectedUser));
 
-        Long joinedUserId = userService.join(user);
-        //when : 실행
-        Optional<User> foundUser = userService.findByUsername(user.getUsername());
-        //then : 검증
+        // when
+        Optional<User> foundUser = userService.findByUsername(username);
+
+        // then
         assertThat(foundUser).isPresent();
-
-        User retrievedUser = foundUser.get();
-        assertThat(retrievedUser.getId()).isEqualTo(joinedUserId);
-        assertThat(retrievedUser.getEmail()).isEqualTo("test1@test1.com");
-        assertThat(retrievedUser.getUsername()).isEqualTo("test1");
-        assertThat(retrievedUser.getRoles()).isEqualTo("ROLE_USER");
-
-
-        // 존재하지 않는 ID로 검색
-       Optional<User> nonExistentUser = userService.findByUsername("nonExistUsername");
-       assertThat(nonExistentUser).isEmpty();
+        assertThat(foundUser.get()).isEqualTo(expectedUser);
+        verify(userRepository).findByUsername(username);
     }
 
+    @Test
+    void userFormDto() {
+        // given
+        UserForm userForm = new UserForm();
+        userForm.setUsername("test");
+        userForm.setPassword("testPassword");
+        userForm.setEmail("test@test.com");
+
+        when(passwordEncoder.encode("testPassword")).thenReturn("encodedPassword");
+
+        // when
+        User user = userService.userFormDTO(userForm);
+
+        // then
+        assertThat(user).isNotNull();
+        assertThat(user.getUsername()).isEqualTo("test");
+        assertThat(user.getEmail()).isEqualTo("test@test.com");
+        assertThat(user.getPassword()).isEqualTo("encodedPassword");
+        verify(passwordEncoder).encode("testPassword");
+    }
 }


### PR DESCRIPTION
- saveBoard 메서드 반환 타입을 void에서 Long으로 변경하여 저장된 게시글의 ID 반환
- 실제 데이터베이스 연결을 통한 통합 테스트 구현
- getBoardPage, getTopViewedBoardPage, getTopCommentCntBoardPage 등 페이지네이션 관련 메서드의 통합 테스트 구현
- getBoardById 메서드에 대한 정상 케이스 및 존재하지 않는 ID 조회 시 예외 발생 테스트 추가
- saveBoard 메서드의 성공 및 실패 시나리오 통합 테스트 구현
- updateBoard 메서드에 대한 성공 및 존재하지 않는 게시글 수정 시도 시 실패 테스트 케이스 추가
- deleteBoard 메서드의 성공, 존재하지 않는 게시글 삭제 시도, 댓글 삭제 실패 시나리오 테스트
- searchBoardsByTitle, searchBoardsByWriter 메서드의 검색 기능 및 결과 없음 케이스 테스트 추가
- getAllBoards 메서드의 정상 동작 및 빈 결과 반환 케이스 테스트
- getBoardByIdAndIncrementViews 메서드의 조회수 증가 기능 및 존재하지 않는 게시글 조회 시 예외 발생 테스트
- incrementViews 메서드의 성공 및 존재하지 않는 게시글 조회수 증가 시도 시 실패 시나리오 테스트
- @Transactional 어노테이션을 활용한 테스트 격리성 확보
- 테스트 데이터 정리를 위한 setUp, tearDown 메서드 구현