### PR TITLE
[test/refactor] : 통합 테스트 추가 및 Repository 파라미터 바인딩 방식 개선

### DIFF
--- a/src/main/java/HomePage/domain/model/User.java
+++ b/src/main/java/HomePage/domain/model/User.java
@@ -1,5 +1,6 @@
 package HomePage.domain.model;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.sql.Timestamp;
@@ -11,11 +12,11 @@ import java.util.List;
 public class User {
 
     private Long id;
-
+    @NotNull
     private String username;
-
+    @NotNull
     private String password;
-
+    @NotNull
     private String email;
     private String roles;
 

--- a/src/main/java/HomePage/repository/CommentRepository.java
+++ b/src/main/java/HomePage/repository/CommentRepository.java
@@ -12,7 +12,7 @@ public interface CommentRepository <T extends Comment> {
     boolean deleteByWriter(String writer);
     boolean deleteByCommentId(Long id);
     boolean deleteByBoardId(Long id);
-    List<T> selectById(Long id);
+    List<T> selectByBoardId(Long id);
     Optional<T> findCommentById(Long commentId);
     int countByBoardId(Long boardId);
     void setTableName(String tableName);

--- a/src/main/java/HomePage/repository/JdbcTemplateUserRepository.java
+++ b/src/main/java/HomePage/repository/JdbcTemplateUserRepository.java
@@ -3,11 +3,11 @@ package HomePage.repository;
 import HomePage.domain.model.User;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 
 import javax.sql.DataSource;
+import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,20 +26,21 @@ public class JdbcTemplateUserRepository implements UserRepository {
 
     @Override
     public User save(User user) {
-        String sql = "INSERT INTO " + tableName + " (username, email, password, role, phoneNumber, provider, providerId) " +
-                             "VALUES (:username, :email, :password, :role, :phoneNumber, :provider, :providerId)";
-
-        MapSqlParameterSource parameters = new MapSqlParameterSource()
-            .addValue("username", user.getUsername())
-            .addValue("password", user.getPassword())
-            .addValue("email", user.getEmail())
-            .addValue("phoneNumber", user.getPhoneNumber())
-            .addValue("role", user.getRoles())
-            .addValue("provider", user.getProvider())
-            .addValue("providerId", user.getProviderId());
-
+        String sql = "INSERT INTO " + tableName + " (username, password, email, role, phoneNumber, provider, providerId) " +
+                                "VALUES (?, ?, ?, ?, ?, ?, ?)";
         KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcTemplate.update(sql, parameters, keyHolder, new String[]{"id"});
+
+        jdbcTemplate.update(connection -> {
+                PreparedStatement ps = connection.prepareStatement(sql, new String[]{"id"});
+                ps.setString(1, user.getUsername());
+                ps.setString(2, user.getPassword());
+                ps.setString(3, user.getEmail());
+                ps.setString(4, user.getRoles());
+                ps.setString(5, user.getPhoneNumber());
+                ps.setString(6, user.getProvider());
+                ps.setString(7, user.getProviderId());
+               return ps;
+        }, keyHolder);
 
         user.setId(keyHolder.getKey().longValue());
         return user;

--- a/src/main/java/HomePage/service/CommunityBoardService.java
+++ b/src/main/java/HomePage/service/CommunityBoardService.java
@@ -133,8 +133,9 @@ public class CommunityBoardService implements BoardService<CommunityBoard>{
 
     @Transactional
     public CommunityBoard getBoardByIdAndIncrementViews(Long id){
-        incrementViews(id);
         CommunityBoard board = getBoardById(id);
+        incrementViews(id);
+        board.setViewCnt(board.getViewCnt() + 1);
         return board;
     }
 

--- a/src/main/java/HomePage/service/CommunityCommentService.java
+++ b/src/main/java/HomePage/service/CommunityCommentService.java
@@ -90,7 +90,7 @@ public class CommunityCommentService implements CommentService<CommunityComment>
 
     @Override
     public List<CommunityComment> getCommentByBoardId(Long id) {
-        return commentRepository.selectById(id);
+        return commentRepository.selectByBoardId(id);
     }
 
     @Override

--- a/src/test/java/HomePage/repository/JdbcTemplateCommunityCommentRepositoryIntegrationTest.java
+++ b/src/test/java/HomePage/repository/JdbcTemplateCommunityCommentRepositoryIntegrationTest.java
@@ -1,0 +1,266 @@
+package HomePage.repository;
+
+import HomePage.domain.model.CommunityBoard;
+import HomePage.domain.model.CommunityComment;
+import HomePage.domain.model.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@Transactional
+class JdbcTemplateCommunityCommentRepositoryIntegrationTest {
+    @Autowired
+    private JdbcTemplateCommunityCommentRepository commentRepository;
+    @Autowired
+    private JdbcTemplateCommunityBoardRepository boardRepository;
+    @Autowired
+    private JdbcTemplateUserRepository userRepository;
+    @Autowired
+    DataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+    private CommunityComment testComment;
+    private CommunityBoard testBoard;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 시작 전 테이블 비우기
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        userRepository.setTableName("test.user");
+        commentRepository.setTableName("test.community_comment");
+        boardRepository.setTableName("test.community_board");
+        cleanUpDatabase();
+
+        // when : 사용자 준비
+        User testUser = new User();
+        testUser.setUsername("testUser");
+        testUser.setEmail("test@test.com");
+        testUser.setPassword("testPassword");
+        testUser.setRoles("ROLE_USER");
+        userRepository.save(testUser);
+
+        User commentUser = new User();
+        commentUser.setUsername("commentUser");
+        commentUser.setEmail("comment@comment.com");
+        commentUser.setPassword("commentPassword");
+        commentUser.setRoles("ROLE_USER");
+        userRepository.save(commentUser);
+
+        // when : 게시판 준비
+        testBoard = new CommunityBoard();
+        testBoard.setWriter("testUser");
+        testBoard.setTitle("Test Board");
+        testBoard.setContent("Test Content");
+        testBoard = boardRepository.save(testBoard);
+
+        // when : 댓글 준비
+        testComment = new CommunityComment();
+        testComment.setBoard_id(testBoard.getId());
+        testComment.setWriter("commentUser");
+        testComment.setContent("Test Comment");
+    }
+
+    @AfterEach
+    void tearDown(){
+        // 테스트 시작 후 테이블 비우기
+        cleanUpDatabase();
+    }
+    private void cleanUpDatabase() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+        jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 0");
+        try {
+            jdbcTemplate.execute("DELETE FROM test.user WHERE id > 1");
+            jdbcTemplate.execute("DELETE FROM test.community_comment WHERE comment_id > 1");
+            jdbcTemplate.execute("DELETE FROM test.community_board WHERE board_id > 1");
+        } finally {
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+            jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 1");
+        }
+    }
+        @Test
+        void save() {
+            // when : 실행
+            CommunityComment savedComment = commentRepository.save(testComment);
+
+            // then : 검증
+            assertNotNull(savedComment.getId());
+            assertEquals(testComment.getBoard_id(), savedComment.getBoard_id());
+            assertEquals(testComment.getWriter(), savedComment.getWriter());
+            assertEquals(testComment.getContent(), savedComment.getContent());
+        }
+
+    @Test
+    void countByBoardId() {
+        //given : 준비
+        CommunityComment savedComment = commentRepository.save(testComment);
+        //when : 실행
+        int result = commentRepository.countByBoardId(savedComment.getBoard_id());
+        //then : 검증
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    void selectAll() {
+        //given : 준비
+        CommunityComment savedComment = commentRepository.save(testComment);
+        //when : 실행
+        List<CommunityComment> communityComments = commentRepository.selectAll();
+        //then : 검증
+        assertThat(communityComments).isNotNull();
+        assertThat(communityComments).hasSize(1);
+        assertThat(communityComments).extracting("Writer").containsExactlyInAnyOrder("commentUser");
+    }
+
+    @Test
+    void update() {
+        //given : 준비
+        CommunityComment savedComment = commentRepository.save(testComment);
+        String updatedContent = "Updated Content";
+        savedComment.setContent(updatedContent);
+        //when : 실행
+        boolean result = commentRepository.update(savedComment);
+        //then : 검증
+        assertThat(result).isTrue();
+        // 업데이트된 댓글 재조회
+        CommunityComment updatedComment = commentRepository.findCommentById(savedComment.getId()).orElse(null);
+        assertThat(updatedComment).isNotNull();
+        assertThat(updatedComment.getContent()).isEqualTo(updatedContent);
+        assertThat(updatedComment.getWriter()).isEqualTo(savedComment.getWriter());
+        assertThat(updatedComment.getBoard_id()).isEqualTo(savedComment.getBoard_id());
+    }
+
+    @Test
+    void findCommentById() {
+        //given : 준비
+        CommunityComment savedComment = commentRepository.save(testComment);
+        //when : 실행
+        CommunityComment foundComment = commentRepository.findCommentById(savedComment.getId()).orElse(null);
+        //then : 검증
+        assertThat(foundComment).isNotNull();
+        assertThat(foundComment.getContent()).isEqualTo(savedComment.getContent());
+        assertThat(foundComment.getWriter()).isEqualTo(savedComment.getWriter());
+        assertThat(foundComment.getBoard_id()).isEqualTo(savedComment.getBoard_id());
+    }
+
+    @Test
+    void selectByBoardId() {
+        //given : 준비
+        CommunityComment savedComment = commentRepository.save(testComment);
+        //when : 실행
+        List<CommunityComment> communityComments = commentRepository.selectByBoardId(testBoard.getId());
+        //then : 검증
+        assertThat(communityComments).isNotEmpty();
+        assertThat(communityComments.get(0).getWriter()).isEqualTo(savedComment.getWriter());
+        assertThat(communityComments.get(0).getContent()).isEqualTo(savedComment.getContent());
+        assertThat(communityComments.get(0).getBoard_id()).isEqualTo(savedComment.getBoard_id());
+    }
+
+    @Test
+    void deleteByWriter() {
+        //given : 준비
+        CommunityComment savedComment = commentRepository.save(testComment);
+        //when : 실행
+        boolean result = commentRepository.deleteByWriter(savedComment.getWriter());
+        //then : 검증
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void deleteByCommentId() {
+        //given : 준비
+        CommunityComment savedComment = commentRepository.save(testComment);
+        //when : 실행
+        boolean result = commentRepository.deleteByCommentId(savedComment.getId());
+        //then : 검증
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void deleteByBoardId() {
+        // given:  준비
+        // 게시판은 beforeEach 어노테이션에서의 setUp메서드 만들어져있음.
+        CommunityComment savedComment = commentRepository.save(testComment);
+        //when : 실행
+        boolean result = commentRepository.deleteByBoardId(testBoard.getId());
+        //then : 검증
+        assertThat(result).isTrue();
+    }
+    @Test
+    void update_NonExistingComment() {
+        //given : 준비
+        CommunityComment nonExistingComment = new CommunityComment();
+        nonExistingComment.setId(9999L); // 존재하지 않는 ID
+        nonExistingComment.setContent("Updated Content");
+        //when : 실행
+        boolean result = commentRepository.update(nonExistingComment);
+        //then : 검증
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void findCommentById_NonExisting() {
+        //when : 실행
+        Optional<CommunityComment> foundComment = commentRepository.findCommentById(9999L);
+        //then : 검증
+        assertThat(foundComment).isEmpty();
+    }
+
+    @Test
+    void selectByBoardId_NonExisting() {
+        //when : 실행
+        List<CommunityComment> communityComments = commentRepository.selectByBoardId(9999L);
+        //then : 검증
+        assertThat(communityComments).isEmpty();
+    }
+
+    @Test
+    void deleteByWriter_NonExisting() {
+        //when : 실행
+        boolean result = commentRepository.deleteByWriter("nonExistingWriter");
+        //then : 검증
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void deleteByCommentId_NonExisting() {
+        //when : 실행
+        boolean result = commentRepository.deleteByCommentId(9999L);
+        //then : 검증
+        assertThat(result).isFalse();
+    }
+
+
+    @Test
+    void save_WithInvalidData() {
+        // given : 준비
+        CommunityComment invalidComment = new CommunityComment();
+        // board_id를 설정하지 않음
+        invalidComment.setWriter("testWriter");
+        invalidComment.setContent("Test Content");
+
+        // when & then : 실행 및 검증
+        assertThatThrownBy(() -> commentRepository.save(invalidComment))
+            .isInstanceOf(Exception.class);  // 예외 타입은 실제 구현에 따라 조정 필요
+    }
+
+    @Test
+    void countByBoardId_NonExisting() {
+        //when : 실행
+        int result = commentRepository.countByBoardId(9999L);
+        //then : 검증
+        assertThat(result).isEqualTo(0);
+    }
+}

--- a/src/test/java/HomePage/repository/JdbcTemplateUserRepositoryIntegrationTest.java
+++ b/src/test/java/HomePage/repository/JdbcTemplateUserRepositoryIntegrationTest.java
@@ -47,10 +47,12 @@ class JdbcTemplateUserRepositoryIntegrationTest {
         cleanUpDatabase();
     }
     private void cleanUpDatabase() {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
         jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 0");
         try {
-            jdbcTemplate.execute("DELETE FROM test.user where id > 1");
+            jdbcTemplate.execute("DELETE FROM test.user WHERE id > 1");
         } finally {
+            jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
             jdbcTemplate.execute("SET SQL_SAFE_UPDATES = 1");
         }
     }
@@ -62,7 +64,7 @@ class JdbcTemplateUserRepositoryIntegrationTest {
         user1.setUsername("user1");
         user1.setEmail("user1@test.com");
         user1.setPassword("password1");
-        user1.setRoles("USER");
+        user1.setRoles("ROLE_USER");
         userRepository.save(user1);
 
         User user2 = new User();
@@ -135,7 +137,7 @@ class JdbcTemplateUserRepositoryIntegrationTest {
 
         //when & then : 실행 및 검증
         assertThatThrownBy(() -> userRepository.save(user))
-            .isInstanceOf(DataIntegrityViolationException.class);
+                .isInstanceOf(DataIntegrityViolationException.class);
     }
 
     @Test

--- a/src/test/java/HomePage/service/CommunityBoardServiceIntegrationTest.java
+++ b/src/test/java/HomePage/service/CommunityBoardServiceIntegrationTest.java
@@ -656,7 +656,7 @@ class CommunityBoardServiceIntegrationTest {
         // when & then : 실행 및 검증
         assertThatThrownBy(() -> boardService.getBoardByIdAndIncrementViews(nonExistingBoardId))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Expected 1 row to be updated, but got ");
+                .hasMessageContaining("Board not found with id: " + nonExistingBoardId);
     }
 
     @Test

--- a/src/test/java/HomePage/service/CommunityBoardServiceUnitTest.java
+++ b/src/test/java/HomePage/service/CommunityBoardServiceUnitTest.java
@@ -535,7 +535,7 @@ class CommunityBoardServiceUnitTest {
         Long nonExistingBoardId = 999L;
 
         when(boardRepository.selectById(nonExistingBoardId)).thenReturn(Optional.empty());
-        when(boardRepository.incrementViews(nonExistingBoardId)).thenReturn(false);
+
         assertThatThrownBy(() -> boardService.getBoardByIdAndIncrementViews(nonExistingBoardId))
             .isInstanceOf(RuntimeException.class)
             .hasMessageContaining("Board not found with id: " + nonExistingBoardId);


### PR DESCRIPTION
- JdbcTemplateCommentRepositoryIntegrationTest 통합 테스트 작성 및 구현
- Repository의 save 메서드 내부 로직 개선:
  - 명명 기반 파라미터(MapSqlParameterSource)에서 위치 기반 파라미터(PreparedStatement)로 변경
  - SQL 쿼리문을 위치 기반 파라미터에 맞게 수정 (`:parameter` -> `?`)
- 변경된 save 메서드에 대한 단위 테스트 수정 및 검증:
  - PreparedStatementCreator 사용에 따른 테스트 로직 변경
  - ArgumentCaptor를 이용한 PreparedStatement 파라미터 설정 검증 추가
- 전체 Repository 테스트 실행 및 정상 동작 확인