### PR TITLE
[feat] : 관리자 페이지 네비게이션 바 구현 및 AdminCommentMapper 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.30'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.mybatis:mybatis:3.5.13'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
 tasks.named('test') {

--- a/src/main/java/HomePage/admin/mapper/AdminCommentMapper.java
+++ b/src/main/java/HomePage/admin/mapper/AdminCommentMapper.java
@@ -1,0 +1,14 @@
+package HomePage.admin.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+@Mapper
+public interface AdminCommentMapper {
+    /*
+        - comment의 boardId값을 통해 삭제
+     * @Param 삭제해야할 boardId를 갖고있는 코멘트들
+     * @return 삭제된 코멘트 갯수
+     */
+    int deleteAllByBoardId(@Param("boardId") Long boardId);
+
+}

--- a/src/main/java/HomePage/admin/service/AdminBoardServiceImpl.java
+++ b/src/main/java/HomePage/admin/service/AdminBoardServiceImpl.java
@@ -1,6 +1,7 @@
 package HomePage.admin.service;
 
 import HomePage.admin.mapper.AdminBoardMapper;
+import HomePage.admin.mapper.AdminCommentMapper;
 import HomePage.domain.model.CommunityBoard;
 import HomePage.domain.model.Page;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,10 +15,11 @@ public class AdminBoardServiceImpl implements AdminBoardService{
     @Value("${communityBoard.page-size}")
     private int pageSize;
     private final AdminBoardMapper adminBoardMapper;
-
+    private final AdminCommentMapper adminCommentMapper;
     @Autowired
-    public AdminBoardServiceImpl(AdminBoardMapper adminBoardMapper) {
+    public AdminBoardServiceImpl(AdminBoardMapper adminBoardMapper, AdminCommentMapper adminCommentMapper) {
        this.adminBoardMapper = adminBoardMapper;
+       this.adminCommentMapper = adminCommentMapper;
     }
 
     @Override
@@ -55,7 +57,6 @@ public class AdminBoardServiceImpl implements AdminBoardService{
         } else {
             return getBoardPage(pageNumber); // 실제로 수행되면 안되는 코드
         }
-
         totalPages = Math.max(1, (int) Math.ceil((double) totalBoards / pageSize));
         return new Page<CommunityBoard>(communityBoards, pageNumber, totalPages, pageSize);
     }
@@ -80,6 +81,7 @@ public class AdminBoardServiceImpl implements AdminBoardService{
     @Override
     @Transactional
     public void deleteBoard(Long id) {
+        adminCommentMapper.deleteAllByBoardId(id);
         adminBoardMapper.deleteById(id);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,6 +40,7 @@ spring.security.oauth2.client.provider.naver.user-name-attribute = response
 spring.mvc.hiddenmethod.filter.enabled=true
 
 spring.thymeleaf.prefix=classpath:/templates/
+spring.thymeleaf.cache=false
 
 communityBoard.page-size=10
 reviewBoard.page-size=20

--- a/src/main/resources/mapper/AdminBoardMapper.xml
+++ b/src/main/resources/mapper/AdminBoardMapper.xml
@@ -34,7 +34,7 @@
 
     <select id="findPageByWriter" resultMap="communityBoardResultMap">
         SELECT * FROM security.communityboard
-        WHERE deleteDate IS NULL AND writer = #{writer}
+        WHERE deleteDate IS NULL AND writer LIKE CONCAT('%' #{writer}, '%')
         ORDER BY regdate DESC
         LIMIT #{limit} OFFSET #{offset}
     </select>
@@ -48,7 +48,7 @@
     </select>
 
     <select id="countByWriter" resultType="int">
-        SELECT COUNT(*) FROM security.communityboard WHERE writer = #{writer}
+        SELECT COUNT(*) FROM security.communityboard WHERE writer LIKE CONCAT('%', #{writer}, '%')
     </select>
 
     <update id="update" parameterType="HomePage.domain.model.CommunityBoard">
@@ -66,7 +66,7 @@
     </select>
 
     <select id="selectByTitle" resultMap="communityBoardResultMap">
-        SELECT * FROM security.communityboard WHERE title LIKE CONCAT('%', #{title}, '%')
+        SELECT * FROM security.communityboard WHERE title = #{title}
     </select>
 
     <select id="selectByWriter" resultMap="communityBoardResultMap">

--- a/src/main/resources/mapper/AdminCommentMapper.xml
+++ b/src/main/resources/mapper/AdminCommentMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="HomePage.admin.mapper.AdminCommentMapper">
+    <resultMap id="communityBoardResultMap" type="HomePage.domain.model.CommunityBoard">
+            <id property="id" column="comment_id"/>
+            <result property="writer" column="writer"/>
+            <result property="boardId" column="board_id"/>
+            <result property="content" column="content"/>
+            <result property="registerDate" column="regdate"/>
+            <result property="updateDate" column="updateDate"/>
+            <result property="deleteDate" column="deleteDate"/>
+    </resultMap>
+    <delete id="deleteAllByBoardId">
+        DELETE FROM security.communitycomment WHERE board_id = #{boardId}
+    </delete>
+</mapper>

--- a/src/main/resources/templates/admin/adminPage.html
+++ b/src/main/resources/templates/admin/adminPage.html
@@ -7,49 +7,85 @@
     <link rel="stylesheet" type="text/css" th:href="@{/css/adminPageStyle.css}">
     <link rel="stylesheet" type="text/css" th:href="@{/css/navBarStyle.css}">
     <link rel="stylesheet" type="text/css" th:href="@{/css/paginationStyle.css}">
+    
+    <style>
+        .search-container {
+            width: 300px;
+            margin: 20px auto;
+        }
+        .deleteBtn {
+            width: 60%;
+            padding: 10px;
+            background-color: #4CAF50;
+            color: white;
+            border: 1px solid #4CAF50;
+            border-radius: 0 4px 4px 0;
+            cursor: pointer;
+        }
+    </style>
 </head>
 <body>
     <header th:replace="~{fragments/navBar :: navBar}">
         <h1>관리자 대시보드</h1>
     </header>
-
     <main>
-        <section id="boardManagement">
-            <h2>게시판 관리</h2>
-            <div class="board-list">
-                <div class="board-header">
-                    <div>ID</div>
-                    <div>제목</div>
-                    <div>작성자</div>
-                    <div>작성일</div>
-                    <div>조회수</div>
-                    <div>관리</div>
+        <div class="content-wrapper">
+            <div class="mainContainer">
+                <div class="leftLayer">
+                    <div th:replace="~{admin/navAdmin :: navAdmin}"></div>
                 </div>
-                <div class="board-item" th:each="board : ${boardPage.content}">
-                    <div th:text="${board.id}"></div>
-                    <div>
-                        <a th:href="@{/community/{id}(id=${board.id}, topic='community', page=${boardPage.currentPage})}"><div th:text="${board.title}"></div></a>
+                <section id="boardManagement">
+                    <h2>게시판 관리</h2>
+                    <div class="board-list">
+                        <div class="search-bar">
+                            <form th:action="@{/api/v1/admin/adminPage/boardList}" method="get">
+                                <input type="hidden" name="page" th:value="1">
+                                <input type="hidden" name="sort" th:value="${sort}">
+                            
+                                
+                                <select name="searchType">
+                                    <option value="title" th:selected="${searchType == 'title'}">제목</option>
+                                    <option value="writer" th:selected="${searchType == 'writer'}">작성자</option>      
+                                </select>
+                                <input type="text" name="searchKeyword" th:value="${searchKeyword}" placeholder="검색어">
+                                <input class="searchButton" type="submit" value="검색"/>
+                            </form>
+                        </div>
+                        <div class="board-header">
+                            <div>ID</div>
+                            <div>제목</div>
+                            <div>작성자</div>
+                            <div>작성일</div>
+                            <div>조회수</div>
+                            <div>관리</div>
+                        </div>
+                        <div class="board-item" th:each="board : ${boardPage.content}">
+                            <div th:text="${board.id}"></div>
+                            <div>
+                                <a th:href="@{/community/{id}(id=${board.id}, topic='community', page=${boardPage.currentPage})}"><div th:text="${board.title}"></div></a>
+                            </div>
+                            <div th:text="${board.writer}"></div>
+                            <div th:text="${board.registerDate}"></div>
+                            <div th:text="${board.viewCnt}"></div>
+                            <div>
+                                <form th:action="@{/api/v1/admin/{id}/editForm(id=${board.id})}">
+                                    <button type="sumbit" class="editBtn">수정</button>
+                                </form>
+                                <form th:action="@{/api/v1/admin/{id}/delete(id=${board.id})}" method="post">
+                                    <input type="hidden" name="_method" value="delete" />
+                                    <button type="sumbit" class="deleteBtn">삭제</button>
+                                </form>
+                            </div>
+                        </div>
                     </div>
-                    <div th:text="${board.writer}"></div>
-                    <div th:text="${board.registerDate}"></div>
-                    <div th:text="${board.viewCnt}"></div>
-                    <div>
-                        <a href="#">수정</a>
-                        <form th:action="@{/api/v1/admin/{id}/delete(id=${board.id})}" method="post">
-                            <input type="hidden" name="_method" value="delete" />
-                            <button type="sumbit" class="deleteBtn">삭제</button>
-                        </form>
-                    </div>
+                </section>
+                
+                <div class="rightLayer">
+
                 </div>
             </div>
-        </section>
+        </div>
         <div class="container">
-            <div>
-                총 페이지: <span th:text="${boardPage.totalPages}"></span>
-                현재 페이지: <span th:text="${boardPage.currentPage}"></span>
-            </div>
-    
-    
             <nav class="pagination-container">
                 <div class="pagination">
                     <button th:if="${boardPage.currentPage > 1}"

--- a/src/main/resources/templates/board/communityBoardList.html
+++ b/src/main/resources/templates/board/communityBoardList.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" type="text/css" th:href="@{/css/communityBoardStyle.css}">
     <link rel="stylesheet" type="text/css" th:href="@{/css/paginationStyle.css}">
     <link rel="stylesheet" type="text/css" th:href="@{/css/navBarStyle.css}">
+    <link rel="stylesheet" type="text/css" th:href="@{/css/navAdminStyle.css}">
     <script th:src="@{/js/dropDown.js}"></script>
     <script th:src="@{/js/elapsedTime.js}"></script>
 </head>

--- a/src/main/resources/templates/fragments/navBar.html
+++ b/src/main/resources/templates/fragments/navBar.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="css/navBarStyle.css">
 </head>
 <body>
-    <nav class="nav-menu"th:fragment="navBar">
+    <nav class="nav-menu" th:fragment="navBar">
         <div class="nav-container">
             <a th:href="@{/index}" class="logo">Gourmet Code</a>
             <ul class="nav-items">


### PR DESCRIPTION
- 관리자 페이지 왼쪽에 세로 네비게이션 바 추가
- 네비게이션 바에 '게시판 관리', '회원 관리' 등의 메뉴 항목 포함
- Thymeleaf를 사용하여 네비게이션 바 템플릿 생성
- CSS를 사용하여 네비게이션 바 스타일링
- AdminCommentMapper 인터페이스 및 XML 매퍼 파일 작성
  - deleteAllByBoardId 메서드 구현

TODO:
- 'admin/navAdmin' 템플릿 로딩 오류 수정 필요
- AdminCommentMapper에 추가 메서드 구현 필요:
  - 댓글 조회, 수정, 개별 삭제 등의 기능 추가
- AdminCommentMapper 테스트 코드 작성