### PR TITLE
[fix] : 쿠키 기반 JWT 사용에 따른 CSRF 토큰 도입

### DIFF
--- a/src/main/java/HomePage/config/CorsConfig.java
+++ b/src/main/java/HomePage/config/CorsConfig.java
@@ -31,7 +31,6 @@ public class CorsConfig {
 //            source.registerCorsConfiguration("/**", corsConfig);
 //
 //        }
-        corsConfig.setAllowCredentials(true);
  //        corsConfig.addAllowedOrigin("http://localhost:3000");
         corsConfig.addAllowedOrigin("http://" + serverAddress);
         corsConfig.addAllowedHeader("*");
@@ -40,10 +39,11 @@ public class CorsConfig {
 
 
         // 노출할 헤더 설정
-                corsConfig.addExposedHeader("ETag");
-                corsConfig.addExposedHeader("Cache-Control");
-                corsConfig.addExposedHeader("If-None-Match");
-                corsConfig.addExposedHeader("If-Match");
+        corsConfig.addExposedHeader("ETag");
+        corsConfig.addExposedHeader("Cache-Control");
+        corsConfig.addExposedHeader("If-None-Match");
+        corsConfig.addExposedHeader("If-Match");
+        corsConfig.setAllowCredentials(true);
 
         source.registerCorsConfiguration("/**", corsConfig);
 

--- a/src/main/java/HomePage/config/CsrfDebugController.java
+++ b/src/main/java/HomePage/config/CsrfDebugController.java
@@ -1,0 +1,16 @@
+package HomePage.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class CsrfDebugController {
+    @GetMapping("/csrf-debug")
+    public String csrfDebug(HttpServletRequest request) {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+        System.out.println("Server-side CSRF Token: " + (csrfToken != null ? csrfToken.getToken() : "NULL"));
+        return "debug";
+    }
+}

--- a/src/main/java/HomePage/config/CustomCookieTokenRepository.java
+++ b/src/main/java/HomePage/config/CustomCookieTokenRepository.java
@@ -1,0 +1,66 @@
+package HomePage.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+
+import java.time.LocalDateTime;
+
+@Configuration
+public class CustomCookieTokenRepository implements CsrfTokenRepository {
+    private final CookieCsrfTokenRepository delegate;
+    private boolean sslEnabled = true;  // 또는 주입받을 수 있음
+
+    public CustomCookieTokenRepository() {
+        this.delegate = CookieCsrfTokenRepository.withHttpOnlyFalse();
+
+        delegate.setCookieCustomizer(cookie -> {
+            if(sslEnabled){
+                cookie.path("/")
+                      .secure(true)
+                      .httpOnly(false)
+                      .maxAge(3600)
+                      .sameSite("None")
+                      .domain(sslEnabled ? "yummuity.com" : "localhost");
+            } else {
+                cookie.path("/")
+                        .secure(true)
+                        .httpOnly(true)
+                        .maxAge(3600)
+                        .sameSite("None")
+                        .domain(sslEnabled ? "yummuity.com" : "localhost");
+            }
+
+        });
+    }
+
+    @Override
+    public CsrfToken generateToken(HttpServletRequest request) {
+        CsrfToken token = delegate.generateToken(request);
+        System.out.println("Root path CSRF Token generated at " + LocalDateTime.now() + ": " + token.getToken());
+        // 요청 URL도 함께 로깅
+        System.out.println("Request URL: " + request.getRequestURL());
+        return token;
+    }
+
+    @Override
+    public void saveToken(CsrfToken token, HttpServletRequest request, HttpServletResponse response) {
+        if(token == null){
+            return;
+        }
+
+        System.out.println("Token saving at " + LocalDateTime.now() + ": " + (token != null ? token.getToken() : "null"));
+        delegate.saveToken(token, request, response);
+    }
+
+    @Override
+    public CsrfToken loadToken(HttpServletRequest request) {
+        CsrfToken token = delegate.loadToken(request);
+        System.out.println("Token loaded at " + LocalDateTime.now() + ": " + (token != null ? token.getToken() : "null"));
+        return token;
+    }
+
+}

--- a/src/main/java/HomePage/config/SecurityConfig.java
+++ b/src/main/java/HomePage/config/SecurityConfig.java
@@ -1,114 +1,115 @@
-package HomePage.config;
+    package HomePage.config;
 
 
-import HomePage.config.jwt.JwtAuthenticationFilter;
-import HomePage.config.jwt.JwtAuthorizationFilter;
-import HomePage.config.jwt.handler.OAuth2LoginSuccessHandler;
-import HomePage.config.jwt.handler.UserLoginSuccessHandler;
-import HomePage.config.oauth.PrincipalOauth2UserService;
-import HomePage.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+    import HomePage.config.jwt.JwtAuthenticationFilter;
+    import HomePage.config.jwt.JwtAuthorizationFilter;
+    import HomePage.config.jwt.handler.OAuth2LoginSuccessHandler;
+    import HomePage.config.jwt.handler.UserLoginSuccessHandler;
+    import HomePage.config.oauth.PrincipalOauth2UserService;
+    import HomePage.repository.UserRepository;
+    import org.springframework.beans.factory.annotation.Autowired;
+    import org.springframework.context.annotation.Bean;
+    import org.springframework.context.annotation.Configuration;
+    import org.springframework.security.authentication.AuthenticationManager;
+    import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+    import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+    import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+    import org.springframework.security.config.http.SessionCreationPolicy;
+    import org.springframework.security.web.SecurityFilterChain;
+    import org.springframework.security.web.csrf.CsrfFilter;
 
-@Configuration
-@EnableWebSecurity
-public class SecurityConfig{
+    @Configuration
+    @EnableWebSecurity
+    public class SecurityConfig{
 
-    @Autowired
-    private PrincipalOauth2UserService principalOauth2UserService;
+        @Autowired
+        private PrincipalOauth2UserService principalOauth2UserService;
 
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private CorsConfig corsConfig;
+        @Autowired
+        private UserRepository userRepository;
+        @Autowired
+        private CorsConfig corsConfig;
 
-    @Autowired
-    private UserLoginSuccessHandler userLoginSuccessHandler;
+        @Autowired
+        private UserLoginSuccessHandler userLoginSuccessHandler;
 
-    @Autowired
-    private OAuth2LoginSuccessHandler oAuthLoginSuccessHandler;
+        @Autowired
+        private OAuth2LoginSuccessHandler oAuthLoginSuccessHandler;
 
-    //AuthenticationConfiguration을 통해서 AuthenticationManager을 가져올 수 있다.
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
-         return authenticationConfiguration.getAuthenticationManager();
-    }
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        @Autowired
+        private CustomCookieTokenRepository customCookieTokenRepository;
 
-        AuthenticationManager authenticationManager = authenticationManager(http.getSharedObject(AuthenticationConfiguration.class));
+        //AuthenticationConfiguration을 통해서 AuthenticationManager을 가져올 수 있다.
+        @Bean
+        public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+             return authenticationConfiguration.getAuthenticationManager();
+        }
 
-        http
-                .headers((headers) ->
-                    headers.disable()
-                )
-//                .addFilterBefore(new Filter3(), SecurityContextHolderFilter.class)
-                .csrf((csrfConfig) ->
-                        csrfConfig.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                )
-                .sessionManagement((sessionManagementConfig) -> sessionManagementConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                .formLogin((formLogin) ->formLogin.disable())
-                .httpBasic((httpBasicConfig) -> httpBasicConfig.disable()
-                )
-                .oauth2Login((oauth2Login) ->
-                                           oauth2Login
-                                                   .loginPage("/loginForm")
-                                                   .defaultSuccessUrl("/index")
-                                                   .failureUrl("/loginForm")
-                                                   .userInfoEndpoint((userInfoEndpoint) ->
-                                                           userInfoEndpoint
-                                                                   .userService(principalOauth2UserService)
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            AuthenticationManager authenticationManager = authenticationManager(http.getSharedObject(AuthenticationConfiguration.class));
 
-                                                   ).successHandler(oAuthLoginSuccessHandler)
-                )
-                .authorizeHttpRequests((authorizeRequests) ->
-                        authorizeRequests
-                                .requestMatchers("/api/v1/community/**").hasAnyRole("USER", "MANAGER", "ADMIN")
-                                .requestMatchers("/api/v1/comments/**").hasAnyRole("USER", "MANAGER", "ADMIN")
-                                .requestMatchers("/api/v1/user/**").hasAnyRole("USER", "MANAGER", "ADMIN")
-                                .requestMatchers("/api/v1/manager/**").hasAnyRole("MANAGER", "ADMIN")
-                                .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                                .anyRequest().permitAll()
-                );
             http
-                .addFilter(corsConfig.corsFilter())
-                .addFilterAt(jwtAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(jwtAuthorizationFilter(authenticationManager), JwtAuthenticationFilter.class);
+                    .headers((headers) ->
+                        headers.disable()
+                    )
+    //                .addFilterBefore(new Filter3(), SecurityContextHolderFilter.class)
+                    .addFilterBefore(corsConfig.corsFilter(), CsrfFilter.class)
+                    .addFilterBefore(jwtAuthenticationFilter(authenticationManager), CsrfFilter.class)  // CSRF 필터 전에 실행
+                    .addFilterBefore(jwtAuthorizationFilter(authenticationManager), CsrfFilter.class)   // CSRF 필터 전에 실행
+                    .csrf(csrf -> csrf
+                        .csrfTokenRepository(customCookieTokenRepository)
+                    )
+                    .sessionManagement((sessionManagementConfig) -> sessionManagementConfig.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                    )
+                    .formLogin((formLogin) ->formLogin.disable())
+                    .httpBasic((httpBasicConfig) -> httpBasicConfig.disable()
+                    )
+                    .oauth2Login((oauth2Login) ->
+                                               oauth2Login
+                                                       .loginPage("/loginForm")
+                                                       .defaultSuccessUrl("/index")
+                                                       .failureUrl("/loginForm")
+                                                       .userInfoEndpoint((userInfoEndpoint) ->
+                                                               userInfoEndpoint
+                                                                       .userService(principalOauth2UserService)
 
-            return http.build();
-    }
+                                                       ).successHandler(oAuthLoginSuccessHandler)
+                    )
+                    .authorizeHttpRequests((authorizeRequests) ->
+                            authorizeRequests
+                                    .requestMatchers("/api/v1/community/**").hasAnyRole("USER", "MANAGER", "ADMIN")
+                                    .requestMatchers("/api/v1/comments/**").hasAnyRole("USER", "MANAGER", "ADMIN")
+                                    .requestMatchers("/api/v1/user/**").hasAnyRole("USER", "MANAGER", "ADMIN")
+                                    .requestMatchers("/api/v1/manager/**").hasAnyRole("MANAGER", "ADMIN")
+                                    .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                                    .anyRequest().permitAll()
+                    );
+
+                return http.build();
+        }
 
 
-    @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationManager authenticationManager){
-        try {
-            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, userRepository, userLoginSuccessHandler);
-            jwtAuthenticationFilter.setAuthenticationManager(authenticationManager);
-//            jwtAuthenticationFilter.setFilterProcessesUrl("/login");
-            jwtAuthenticationFilter.setAuthenticationSuccessHandler(userLoginSuccessHandler);
-            return jwtAuthenticationFilter;
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create JwtAuthenticationFilter", e);
+        @Bean
+        public JwtAuthenticationFilter jwtAuthenticationFilter(AuthenticationManager authenticationManager){
+            try {
+                JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, userRepository, userLoginSuccessHandler);
+                jwtAuthenticationFilter.setAuthenticationManager(authenticationManager);
+    //            jwtAuthenticationFilter.setFilterProcessesUrl("/login");
+                jwtAuthenticationFilter.setAuthenticationSuccessHandler(userLoginSuccessHandler);
+                return jwtAuthenticationFilter;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to create JwtAuthenticationFilter", e);
+            }
+        }
+        @Bean
+        public JwtAuthorizationFilter jwtAuthorizationFilter(AuthenticationManager authenticationManager){
+            try{
+                JwtAuthorizationFilter jwtAuthorizationFilter = new JwtAuthorizationFilter(authenticationManager, userRepository);
+
+                return jwtAuthorizationFilter;
+            } catch (Exception e){
+                throw new RuntimeException("Failed to create JwtAuthenticationFilter", e);
+            }
         }
     }
-    @Bean
-    public JwtAuthorizationFilter jwtAuthorizationFilter(AuthenticationManager authenticationManager){
-        try{
-            JwtAuthorizationFilter jwtAuthorizationFilter = new JwtAuthorizationFilter(authenticationManager, userRepository);
-
-            return jwtAuthorizationFilter;
-        } catch (Exception e){
-            throw new RuntimeException("Failed to create JwtAuthenticationFilter", e);
-        }
-    }
-}

--- a/src/main/java/HomePage/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/HomePage/config/jwt/JwtAuthorizationFilter.java
@@ -31,7 +31,6 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         String accessToken = tokenProvider.getAccessTokenFromRequest(request);
-
         if (accessToken == null){  // accessToken이 없으면 종료하고 다음 체인
             chain.doFilter(request, response);
             return;

--- a/src/main/java/HomePage/controller/AuthenticationController.java
+++ b/src/main/java/HomePage/controller/AuthenticationController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import java.io.IOException;
+
 @Controller
 @CrossOrigin(origins = "http://localhost:3000", exposedHeaders = "Authorization")
 public class AuthenticationController {
@@ -40,7 +42,7 @@ public class AuthenticationController {
         return "login/loginForm";
     }
     @PostMapping("/api/logout")
-    public String logout(HttpServletRequest request, HttpServletResponse response){
+    public void logout(HttpServletRequest request, HttpServletResponse response) throws IOException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if(authentication != null){
@@ -53,7 +55,7 @@ public class AuthenticationController {
         cookie.setPath("/");
         response.addCookie(cookie);
 
-
-        return "redirect:/loginForm";
+        // redirect를 직접 수행
+        response.sendRedirect("/loginForm");
     }
 }

--- a/src/main/java/HomePage/controller/AuthenticationRestController.java
+++ b/src/main/java/HomePage/controller/AuthenticationRestController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class AuthenticationRestController {
-   @GetMapping("/auth/status")
+   @GetMapping("/api/auth/status")
    public ResponseEntity<String> getAuthStatus(Authentication authentication) {
        boolean isAuthenticated = false;
 
@@ -21,7 +21,7 @@ public class AuthenticationRestController {
                isAuthenticated = true;
            }
        }
-       System.out.println(isAuthenticated);
+       System.out.println("isAuthenticated" + isAuthenticated);
 
        return ResponseEntity.ok()
            .cacheControl(CacheControl.noCache())

--- a/src/main/resources/static/js/loginValidate.js
+++ b/src/main/resources/static/js/loginValidate.js
@@ -1,29 +1,33 @@
 async function validateLogin() {
-    var username = document.getElementById("LoginUsername").value;
-    var password = document.getElementById("LoginPassword").value;
-    
-    if (!username || !password){
+    const username = document.getElementById("LoginUsername").value;
+    const password = document.getElementById("LoginPassword").value;
+
+    if (!username || !password) {
         alert('아이디나 패스워드를 입력해주세요');
         return false;
     }
 
+    // CSRF 토큰 가져오기 (서버에서 전달하는 방식 사용)
+    const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content'); // 예시: meta 태그 사용
 
-    const token = document.querySelector("meta[name='_csrf']").content;
-    const header = document.querySelector("meta[name='_csrf_header']").content;
-
+    if (!csrfToken) {
+        console.error("CSRF token not found!");
+        alert("CSRF 토큰을 찾을 수 없습니다. 다시 시도해주세요.");
+        return false;
+    }
+    console.log(csrfToken);
     const response = await fetch('/api/check-user', {
         method: 'POST',
-        credentials: 'same-origin',
         headers: {
             'Content-Type': 'application/json',
-            [header]: token  // CSRF 토큰 추가
+            'X-XSRF-TOKEN': csrfToken // 서버에서 사용하는 CSRF 토큰 헤더 이름에 맞게 변경
         },
         body: JSON.stringify({
-            username: username, 
+            username: username,
             password: password
         })
     });
-    
+
     const data = await response.json();
     if (data.exists) {
         return true;

--- a/src/main/resources/static/js/updateAuthButton.js
+++ b/src/main/resources/static/js/updateAuthButton.js
@@ -1,5 +1,5 @@
 function updateAuthButtons() {
-    fetch('/auth/status')
+    fetch('/api/auth/status')
         .then(response => response.text())
         .then(isAuthenticated => {
             const authContent = document.querySelector('.nav-right');
@@ -9,25 +9,28 @@ function updateAuthButtons() {
                 existingAuthButton.parentElement.remove();
             }
 
-            if(isAuthenticated === 'anonymous') {
+            if(isAuthenticated === 'authenticated') {
+                const logoutDiv = document.createElement('div');
+                // form을 그대로 submit하도록 변경
+                logoutDiv.innerHTML = `
+                    <form action="/api/logout" method="post">
+                        <input type="hidden" name="_csrf" value="${document.querySelector("meta[name='_csrf']").content}" />
+                        <button type="submit" class="auth-button" id="logoutButton">로그아웃</button>
+                    </form>
+                `;
+                authContent.insertBefore(logoutDiv, authContent.firstChild);
+            } else if(isAuthenticated === 'anonymous') {
                 const authDiv = document.createElement('div');
                 authDiv.innerHTML = `
                     <button class="auth-button" id="authButton">
                         <a href="/loginForm">로그인/회원가입</a>
                     </button>
                 `;
-                // 맨 앞에 추가
                 authContent.insertBefore(authDiv, authContent.firstChild);
-            } else {
-                const logoutDiv = document.createElement('div');
-                logoutDiv.innerHTML = `
-                    <form action="/api/logout" method="post">
-                        <button type="submit" class="auth-button" id="logoutButton">로그아웃</button>
-                    </form>
-                `;
-                // 맨 앞에 추가
-                authContent.insertBefore(logoutDiv, authContent.firstChild);
             }
+        })
+        .catch(error => {
+            console.error('Authentication status check failed:', error);
         });
 }
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -30,7 +30,18 @@
                 </h2>
             </div>
         </div>
+        <form action="/api/logout" method="post">
+            <input type="hidden" name="${_csrf_header}" value="${_csrf.token}" />
+           <button type="submit" class="auth-button" id="logoutButton">로그아웃</button>
+       </form>
     </main>
+    <script>
+        const token = document.querySelector("meta[name='_csrf']").content;
+        const header = document.querySelector("meta[name='_csrf_header']").content;
+        
+        console.log(token);
+        console.log(header);
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
- CookieCsrfTokenRepository 커스텀 구현으로 CSRF 토큰 생명주기 관리 (기존 CookieCsrfTokenRepository 로직은 내 설정 환경에 문제가 있음)
- JWT를 Authorization 헤더가 아닌 쿠키로 전송하여 CSRF 공격 방지 필요
- CSRF 토큰의 불필요한 재생성 방지
- 쿠키 보안 설정 강화 (Secure, SameSite 속성 추가)