### PR TITLE
[feat] : communityComment 좋아요 기능 추가 - 2

### DIFF
--- a/src/main/java/HomePage/controller/board/CommunityBoardController.java
+++ b/src/main/java/HomePage/controller/board/CommunityBoardController.java
@@ -111,7 +111,7 @@ public class CommunityBoardController {
             PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
             Long userId = principalDetails.getUser().getId();
 
-            comments = commentService.getCommentByBoardId(id, userId);// 게시글 id와 userId 를 통해서 해당 게시글의 댓글들을 불러온다.l
+            comments = commentService.getCommentByBoardIdWithUser(id, userId);// 게시글 id와 userId 를 통해서 해당 게시글의 댓글들을 불러온다.l
 
         }
 

--- a/src/main/java/HomePage/mapper/CommunityCommentMapper.java
+++ b/src/main/java/HomePage/mapper/CommunityCommentMapper.java
@@ -26,7 +26,7 @@ public interface CommunityCommentMapper {
         CommunityComment findCommentById(Long commentId);
         List<CommunityCommentDTO> selectByBoardId(@Param("boardId") Long boardId);
         // 수정된 메서드: userId 파라미터 추가
-        List<CommunityCommentDTO> selectByBoardId(@Param("boardId") Long boardId, @Param("userId") Long userId);
+        List<CommunityCommentDTO> selectByBoardIdWithUser(@Param("boardId") Long boardId, @Param("userId") Long userId);
 
         List<CommunityCommentDTO> selectByWriter(String writer);
 

--- a/src/main/java/HomePage/service/CommentService.java
+++ b/src/main/java/HomePage/service/CommentService.java
@@ -15,7 +15,7 @@ public interface CommentService <T extends Comment> {
     void deleteCommentsByBoardId(Long id);
     T getCommentByCommentId(Long CommentId);
     List<CommunityCommentDTO> getCommentByBoardId(Long boardId);
-    List<CommunityCommentDTO> getCommentByBoardId(Long boardId, Long userId);
+    List<CommunityCommentDTO> getCommentByBoardIdWithUser(Long boardId, Long userId);
     List<CommunityCommentDTO> getAllComments();
 
     int countByBoardId(Long id);

--- a/src/main/java/HomePage/service/CommunityCommentService.java
+++ b/src/main/java/HomePage/service/CommunityCommentService.java
@@ -99,8 +99,8 @@ public class CommunityCommentService implements CommentService<CommunityComment>
     }
 
     @Override
-    public List<CommunityCommentDTO> getCommentByBoardId(Long boardId, Long userId) {
-        List<CommunityCommentDTO> communityCommentDTOS = commentMapper.selectByBoardId(boardId, userId);
+    public List<CommunityCommentDTO> getCommentByBoardIdWithUser(Long boardId, Long userId) {
+        List<CommunityCommentDTO> communityCommentDTOS = commentMapper.selectByBoardIdWithUser(boardId, userId);
         return communityCommentDTOS;
     }
 

--- a/src/main/resources/mapper/CommunityCommentMapper.xml
+++ b/src/main/resources/mapper/CommunityCommentMapper.xml
@@ -117,6 +117,8 @@
         WHERE board_id = #{id}
     </delete>
 
+
+    <!-- 비로그인 사용자용 -->
     <select id="selectByBoardId" resultMap="communityCommentResultMap">
         SELECT
             c.comment_id,
@@ -127,17 +129,62 @@
             c.updatedAt,
             c.deletedAt,
             b.title as board_title,
-            ul.isLike as user_like_status
+            c.like_count,
+            c.dislike_count,
+            NULL as user_like_status
         FROM
             security.communitycomment c
             LEFT JOIN security.communityboard b ON c.board_id = b.board_id
-            LEFT JOIN security.likes ul ON c.comment_id = ul.target_id
-                AND ul.target_type = 'COMMENT'
-                AND ul.user_id = #{userId}
         WHERE
             c.board_id = #{boardId}
         ORDER BY
             c.createdAt DESC
+    </select>
+
+    <!-- 로그인 사용자용 -->
+    <select id="selectByBoardIdWithUser" resultMap="communityCommentResultMap">
+<!--        SELECT-->
+<!--            c.comment_id,-->
+<!--            c.board_id,-->
+<!--            c.writer,-->
+<!--            c.content,-->
+<!--            c.createdAt,-->
+<!--            c.updatedAt,-->
+<!--            c.deletedAt,-->
+<!--            b.title as board_title,-->
+<!--            ul.isLike as user_like_status-->
+<!--        FROM-->
+<!--            security.communitycomment c-->
+<!--            LEFT JOIN security.communityboard b ON c.board_id = b.board_id-->
+<!--            LEFT JOIN security.likes ul ON c.comment_id = ul.target_id-->
+<!--                AND ul.target_type = 'COMMENT'-->
+<!--                AND ul.user_id = #{userId}-->
+<!--        WHERE-->
+<!--            c.board_id = #{boardId}-->
+<!--        ORDER BY-->
+<!--            c.createdAt DESC-->
+        SELECT
+               c.comment_id,
+               c.board_id,
+               c.writer,
+               c.content,
+               c.createdAt,
+               c.updatedAt,
+               c.deletedAt,
+               b.title as board_title,
+               c.like_count,
+               c.dislike_count,
+               ul.isLike as user_like_status
+           FROM
+               security.communitycomment c
+               LEFT JOIN security.communityboard b ON c.board_id = b.board_id
+               LEFT JOIN security.likes ul ON c.comment_id = ul.target_id
+                   AND ul.target_type = 'COMMENT'
+                   AND ul.user_id = #{userId}
+           WHERE
+               c.board_id = #{boardId}
+           ORDER BY
+               c.createdAt DESC
     </select>
 
     <select id="selectAll" resultMap="communityCommentResultMap">


### PR DESCRIPTION
- 커뮤니티 댓글에 대한 좋아요/싫어요 기능 구현
 - 좋아요/싫어요 처리를 위한 XML Mapper 수정
 - updateReviewCounts 메서드 업데이트하여 커뮤니티 댓글 테이블 지원
 - 좋아요/싫어요 동작 처리 로직 추가
 - 로그인/비로그인 사용자 구분하여 댓글 조회 기능 분리
   - selectByBoardId: 비로그인 사용자용 댓글 조회
   - selectByBoardIdWithUser: 로그인 사용자용 좋아요 상태 포함 댓글 조회

- 좋아요/싫어요 UI 상호작용 구현
 - 버튼 클릭 시 활성화/비활성화 상태 변경
 - 카운트 실시간 업데이트